### PR TITLE
Fix IE10

### DIFF
--- a/locales/i18n.js
+++ b/locales/i18n.js
@@ -26,8 +26,11 @@ function getMessages(locale) {
   return assign({}, directories['en-US'], messages);
 }
 
-
-var locale = formatLocale(navigator.language);
+//This is an easy cross browser way to get the preferred language
+/** @const */ var DEFAULT_VALUE = 'en';
+/** @const */ var PREFERRED_LANGUAGE = navigator.language || navigator.userLanguage ||
+                  navigator.browserLanguage || navigator.systemLanguage || DEFAULT_VALUE;
+var locale = formatLocale(PREFERRED_LANGUAGE);
 module.exports = {
   intlData: {
     locales : ['en-US'],


### PR DESCRIPTION
IE10 doesn't support navigator.language, but we can default to
navigator.browserLanguage which is enough to get anyone to donate to us
based on their language setting of the browser