### PR TITLE
insure we don't override async state changes with old data

### DIFF
--- a/mixins/form.jsx
+++ b/mixins/form.jsx
@@ -60,9 +60,9 @@ module.exports = {
     });
   },
   onChange: function(name, value, field) {
-    var newState = this.state;
+    var newState = {};
     newState[name] = value;
-    if (field && newState.errors[name] && newState.errors[name][field]) {
+    if (field && this.state.errors[name] && this.state.errors[name][field]) {
       newState.errors[name][field] = "";
     }
     this.setState(newState);
@@ -178,7 +178,7 @@ module.exports = {
     this.transitionTo('/' + this.props.locales[0] + '/thank-you/?' + params);
   },
   stripeError: function(error) {
-    var newState = this.state;
+    var newState = {};
     var cardErrorCodes = {
       "invalid_number": {
         name: "creditCardInfo",
@@ -229,12 +229,12 @@ module.exports = {
     var cardError = cardErrorCodes[error.code];
     newState.submitting = false;
     if (error.rawType === "card_error" && cardError) {
-      if (newState.errors[cardError.name].page < newState.activePage) {
+      if (this.state.errors[cardError.name].page < this.state.activePage) {
         newState.activePage = newState.errors[cardError.name].page;
       }
       newState.errors[cardError.name][cardError.field] = cardError.message;
     } else {
-      if (newState.errors.other.page < newState.activePage) {
+      if (this.state.errors.other.page < this.state.activePage) {
         newState.activePage = newState.errors.other.page;
       }
       newState.errors.other.message = this.getIntlMessage('try_again_later');


### PR DESCRIPTION
I noticed this bug while working on another patch that's still a WIP, decided to split it up into a seperate bug, thus, no STRs yet because we don't really trigger the error in the current code base.

Fundamentally, it's pretty busted though.

setState changes are not sync, they are async. So if you have an event that calls some helper functions in a mixin that set state, and then set state outside of the helper function as well, the timing could be weird.

If this happens, you have to ensure you don't reset old data. You should never do something like this.

```
var newState = this.state;

newState[prop] = "1";

this.setState(newState);
```

If you do that, it may revert data you have set elsewhere. It's caching this.state, and another setState could resolve before the cached state does, thus reverting it.