### PR TITLE
busted stripe errors

### DIFF
--- a/mixins/form.jsx
+++ b/mixins/form.jsx
@@ -226,16 +226,18 @@ module.exports = {
         message: this.getIntlMessage('declined_card')
       }
     };
+
     var cardError = cardErrorCodes[error.code];
     newState.submitting = false;
+    newState.errors = this.state.errors;
     if (error.rawType === "card_error" && cardError) {
       if (this.state.errors[cardError.name].page < this.state.activePage) {
-        newState.activePage = newState.errors[cardError.name].page;
+        newState.activePage = this.state.errors[cardError.name].page;
       }
       newState.errors[cardError.name][cardError.field] = cardError.message;
     } else {
       if (this.state.errors.other.page < this.state.activePage) {
-        newState.activePage = newState.errors.other.page;
+        newState.activePage = this.state.errors.other.page;
       }
       newState.errors.other.message = this.getIntlMessage('try_again_later');
     }


### PR DESCRIPTION
I just missed some state scope while doing a recent patch, and broke the error handling.

STR:
1. test a declined card: 4000000000000002
2. fill in the rest of the form with valid test data.

Expected: should swing you to page 2 with an error about the card being declined
Actual: just spins, and eventually throws a console error with something being undefined.