### PR TITLE
fixing paypal locales

### DIFF
--- a/components/simple-paypal.jsx
+++ b/components/simple-paypal.jsx
@@ -5,6 +5,7 @@ import AmountButtons from '../components/amount-buttons.jsx';
 import Frequency from '../components/donation-frequency.jsx';
 import SubmitButton from '../components/submit-button.jsx';
 import DonateButton from '../components/donate-button.jsx';
+import {paypalLocales} from '../intl-config.json';
 
 var simplePaypal = React.createClass({
   mixins: [IntlMixin, require('../mixins/form.jsx')],
@@ -88,7 +89,7 @@ var simplePaypal = React.createClass({
         <form action={process.env.PAYPAL_ENDPOINT + "/cgi-bin/webscr"} method="post" target="_top" ref="paypalOneTime">
           <input type="hidden" name="cmd" value="_donations"/>
           <input type="hidden" name="business" value={process.env.PAYPAL_EMAIL}/>
-          <input type="hidden" name="lc" value="US"/>
+          <input type="hidden" name="lc" value={paypalLocales[this.props.locales[0]]}/>
           <input type="hidden" name="item_name" value={this.getIntlMessage("mozilla_donation")}/>
           <input type="hidden" name="no_note" value="1"/>
           <input type="hidden" name="no_shipping" value="1"/>
@@ -102,7 +103,7 @@ var simplePaypal = React.createClass({
         <form action={process.env.PAYPAL_ENDPOINT + "/cgi-bin/webscr"} method="post" ref="paypalRecurring">
           <input type="hidden" name="cmd" value="_xclick-subscriptions"/>
           <input type="hidden" name="business" value={process.env.PAYPAL_EMAIL}/>
-          <input type="hidden" name="lc" value="US"/>
+          <input type="hidden" name="lc" value={paypalLocales[this.props.locales[0]]}/>
           <input type="hidden" name="item_name" value={this.getIntlMessage("mozilla_monthly_donation")}/>
           <input type="hidden" name="no_note" value="1"/>
           <input type="hidden" name="no_shipping" value="2"/>

--- a/intl-config.json
+++ b/intl-config.json
@@ -1,7 +1,7 @@
 {
-	"supportedLocales": ["en-US", "de", "fr", "pt-BR", "es", "id"],
-	"dest": "locales",
-	"src": "locales",
+  "supportedLocales": ["en-US", "de", "fr", "pt-BR", "es", "id"],
+  "dest": "locales",
+  "src": "locales",
   "paypalLocales": {
     "en-US": "US",
     "de": "DE",

--- a/intl-config.json
+++ b/intl-config.json
@@ -1,5 +1,12 @@
 {
 	"supportedLocales": ["en-US", "de", "fr", "pt-BR", "es", "id"],
 	"dest": "locales",
-	"src": "locales"
+	"src": "locales",
+  "paypalLocales": {
+    "en-US": "US",
+    "de": "DE",
+    "fr": "FR",
+    "pt-BR": "BR",
+    "id": "id_ID"
+  }
 }

--- a/mixins/form.jsx
+++ b/mixins/form.jsx
@@ -136,7 +136,7 @@ module.exports = {
   },
   submit: function(action, props, callback) {
     props.locale = this.props.locales[0];
-    props.currency = this.props.currency.code;
+    props.currency = this.state.currency.code;
     fetch(action, {
       method: 'post',
       credentials: 'same-origin',

--- a/routes/index.js
+++ b/routes/index.js
@@ -84,7 +84,7 @@ var routes = {
       paypal.setupSingle({
         amount: transaction.amount,
         currency: transaction.currency,
-        locale: transaction.localeCode,
+        locale: transaction.locale,
         item_name: transaction.description,
         cancelUrl: request.server.info.uri + '/',
         returnUrl: request.server.info.uri + '/api/paypal-one-time-redirect'
@@ -101,7 +101,7 @@ var routes = {
       paypal.setupRecurring({
         amount: transaction.amount,
         currency: transaction.currency,
-        locale: transaction.localeCode,
+        locale: transaction.locale,
         item_name: transaction.description,
         cancelUrl: request.server.info.uri + '/',
         returnUrl: request.server.info.uri + '/api/paypal-recurring-redirect'

--- a/routes/paypal.js
+++ b/routes/paypal.js
@@ -1,5 +1,6 @@
 var httpRequest = require('request');
 var querystring = require('querystring');
+var paypalLocales = require('../intl-config.json').paypalLocales;
 
 function setupPaypal(transaction, recurring, callback) {
   var charge = {
@@ -12,7 +13,7 @@ function setupPaypal(transaction, recurring, callback) {
     PAYMENTREQUEST_0_AMT: transaction.amount,
     PAYMENTREQUEST_0_DESC: transaction.item_name,
     PAYMENTREQUEST_0_CURRENCYCODE: transaction.currency.toUpperCase(),
-    LOCALECODE: transaction.locale,
+    LOCALECODE: paypalLocales[transaction.locale],
     NOSHIPPING: '1',
     ALLOWNOTE: '0',
     cancelUrl: transaction.cancelUrl,


### PR DESCRIPTION
Fixing the locale for paypal's login screen.

Few things to note:

1. once logged in, it uses that account's settings locale, and our current test account is a US account. We just control the login screen locale.

2. It also for some reason caches the last used locale, and ignore the one we set. So to test each of these, you need to test them in new private tabs.