### PR TITLE
Bug 1115727 - Open Sans font on sendto.mozilla.org does not render well characters with diacritics

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -18,7 +18,7 @@ var Index = React.createClass({
           <title>donate.mozilla.org | Give to Mozilla Today</title>
           <OptimizelySubdomain/>
           <Optimizely/>
-          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic"/>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic&subset=latin-ext"/>
           <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css" rel="stylesheet"/>
           <link rel="icon" href="/images/favicon.ico" type="image/x-icon"/>
           <link rel="stylesheet" href="/css/index.css"/>


### PR DESCRIPTION
This fixes [Bug 1115727](https://bugzilla.mozilla.org/show_bug.cgi?id=1115727) for Czech. Not sure if it does not break other locales, but should not, as https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic is the same as https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic&subset=latin (no latin-ext).

Anyway, shouldn't be used mozorg.cdn.mozilla.net hosted fonts instead of Google?