### PR TITLE
improve email error

### DIFF
--- a/components/email-input.jsx
+++ b/components/email-input.jsx
@@ -9,7 +9,8 @@ var EmailInput = React.createClass({
       values: {
         email: ""
       },
-      valid: true
+      valid: true,
+      errorMessage: ""
     };
   },
   componentDidMount: function() {
@@ -17,8 +18,14 @@ var EmailInput = React.createClass({
   },
   validate: function() {
     var valid = !!this.state.values.email;
+    var errorMessage = "";
+    if (!this.refs.inputElement.getDOMNode().validity.valid) {
+      valid = false;
+      errorMessage = this.getIntlMessage('email_invalid');
+    }
     this.setState({
-      valid: valid
+      valid: valid,
+      errorMessage: errorMessage
     });
     return valid;
   },
@@ -64,14 +71,29 @@ var EmailInput = React.createClass({
     if (!this.state.valid) {
       inputClassName += "parsley-error";
     }
+    var errorMessageClassName = "row error-msg-row";
+    if (!this.state.errorMessage) {
+      errorMessageClassName += " hidden";
+    }
     return (
       <div className="cc-additional-info" id="email-row">
         <div className="row hint-msg-parent">
           <div className="full">
             <div className="field-container">
               <i className="fa fa-envelope field-icon"></i>
-              <input type="email" className={inputClassName} name="email" value={this.state.values.email} onChange={this.onEmailChange} placeholder={this.getIntlMessage('email')}/>
+              <input type="email" ref="inputElement" className={inputClassName} name="email" value={this.state.values.email} onChange={this.onEmailChange} placeholder={this.getIntlMessage('email')}/>
               {this.renderHint()}
+            </div>
+          </div>
+        </div>
+        <div className={errorMessageClassName}>
+          <div className="full">
+            <div id="amount-error-msg">
+              <ul id="parsley-id-multiple-donation_amount" className="parsley-errors-list filled">
+                <li className="parsley-custom-error-message">
+                  {this.state.errorMessage}
+                </li>
+              </ul>
             </div>
           </div>
         </div>

--- a/less/shared.less
+++ b/less/shared.less
@@ -347,6 +347,9 @@ input[type="email"],
 input[type="tel"],
 #amount-other-input {
   padding: 7px 30px 7px 33px;
+  &:invalid {
+    box-shadow: none;
+  }
 }
 
 input[type="text"]:focus,

--- a/locales/de/messages.properties
+++ b/locales/de/messages.properties
@@ -77,6 +77,7 @@ mozilla_monthly_donation=Monatliche Spende an die Mozilla Foundation
 help_protect_the_web=Helfen Sie beim Schutz des offenen Webs.
 Bitcoin=Bitcoin
 donation_notice_bitcoin=Die Mozilla Foundation ist eine gemeinnützige Gesellschaft in Kalifornien und ist laut IRC 501(c)(3) von der Bundeseinkommenssteuer befreit und außerdem gemäß IRC-Abschnitt 170(b)(1)(A) und 509(a)(1) ein gemeinnütziger Verein. Bitcoin-Spenden an Mozilla gelten als Spenden für wohltätige Zwecke im Sinne des US-Bundessteuergesetzes, die nach eigenem Ermessen für wohltätige Zwecke genutzt werden. Wenn Sie Fragen haben, lesen Sie <a href="https://wiki.mozilla.org/Donate">unsere FAQ</a> oder schreiben Sie uns unter <a href="mailto:donate@mozilla.org">donate@mozilla.org</a>.
+email_invalid=Überprüfen Sie bitte, ob Sie eine gültige E-Mail-Adresse eingetragen haben.
 
 # some of these strings are not or will on the page, or some of them will be use for email/snippets only
 this_really_help_us=Das hilft uns wirklich weiter!

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -78,6 +78,7 @@ mozilla_monthly_donation=Mozilla Foundation Monthly Donation
 help_protect_the_web=Help protect the open Web.
 Bitcoin=Bitcoin
 donation_notice_bitcoin=The Mozilla Foundation is a California non-profit corporation exempt from United States federal income taxation under IRC 501(c)(3) and a public charity classified under IRC sections 170(b)(1)(A) and 509(a)(1). Bitcoin donations Mozilla receives are considered charitable contributions under U.S. federal tax laws, to be used in its discretion for its charitable purposes. If you have questions, check out <a href="https://wiki.mozilla.org/Donate">our FAQ</a> or contact us at <a href="mailto:donate@mozilla.org">donate@mozilla.org</a>.
+email_invalid=Please make sure you have entered a valid email address.
 
 # some of these strings are not or will on the page, or some of them will be use for email/snippets only
 this_really_help_us=This really helps us!


### PR DESCRIPTION
What this is doing is differentiating between invalid emails and empty inputs.

I got the translated string from the petition, along with the English version so I can be pretty sure they match.

Fixes #414