### PR TITLE
Fix dropdown weird position on Chrome

### DIFF
--- a/less/components/currency-dropdown.less
+++ b/less/components/currency-dropdown.less
@@ -1,9 +1,8 @@
 .currency-dropdown {
-  width: 80px;
   font-size: 14px;
   text-transform: uppercase;
-  padding: 0;
   text-align: center;
+  padding: 0 20px;
   option {
     padding: 0;
   }


### PR DESCRIPTION
This annoys me a bit that in Chrome the currency dropdown looks really
weird