### PR TITLE
Use official Russian ruble currency symbol instead of abbreviation

### DIFF
--- a/data/currencies.js
+++ b/data/currencies.js
@@ -196,7 +196,7 @@ module.exports = {
   'rub': {
     code: 'rub',
     minAmount: '100',
-    symbol: 'руб',
+    symbol: '₽',
     presets: {
       single: ['1000', '500', '250', '140'],
       monthly: ['250', '180', '120', '100']


### PR DESCRIPTION
Use official Russian ruble currency symbol instead of abbreviation, see https://en.wikipedia.org/wiki/Russian_ruble#Currency_symbol