### PR TITLE
Allow changing newsletter type in HTML

### DIFF
--- a/components/signup.jsx
+++ b/components/signup.jsx
@@ -23,6 +23,7 @@ var Form = React.createClass({
           <div className="wrap">
             <div className="row">
               <Email name="email"/>
+              <input type="hidden" name="newsletters" value="mozilla-foundation"/>
               <div className="full country-signup">
                 <Country name="country"/>
               </div>

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -8,7 +8,7 @@ module.exports = function(transaction, callback) {
     form: {
       format: 'html',
       lang: transaction.locale,
-      newsletters: 'mozilla-foundation',
+      newsletters: transaction.newsletters,
       trigger_welcome: 'N',
       source_url: 'https://donate.mozilla.org/',
       email: transaction.email,


### PR DESCRIPTION
As part of the Mozlando Engagement project mentioned in #1081, we’d like to dynamically change the newsletter slug which is currently hardcoded in a route. It can be a hidden input control like https://www.mozilla.org/en-US/newsletter/

@alicoding r?