### PR TITLE
Add/donor messages

### DIFF
--- a/components/signup.jsx
+++ b/components/signup.jsx
@@ -8,7 +8,9 @@ import SubmitButton from '../components/submit-button.jsx';
 var Form = React.createClass({
   mixins: [IntlMixin, require('../mixins/form.jsx')],
   render: function() {
-    return (
+    // Display unless told otherwise
+    var shouldDisplay = this.props.shouldDisplay === undefined ? true : this.props.shouldDisplay;
+    return shouldDisplay ? (
       <div>
         <div className="container">
           <div className="wrap">
@@ -53,7 +55,7 @@ var Form = React.createClass({
           </div>
         </div>
       </div>
-    );
+    ) : null;
   }
 
 });

--- a/components/signup.jsx
+++ b/components/signup.jsx
@@ -8,9 +8,7 @@ import SubmitButton from '../components/submit-button.jsx';
 var Form = React.createClass({
   mixins: [IntlMixin, require('../mixins/form.jsx')],
   render: function() {
-    // Display unless told otherwise
-    var shouldDisplay = this.props.shouldDisplay === undefined ? true : this.props.shouldDisplay;
-    return shouldDisplay ? (
+    return this.props.isHidden ? null : (
       <div>
         <div className="container">
           <div className="wrap">
@@ -55,7 +53,7 @@ var Form = React.createClass({
           </div>
         </div>
       </div>
-    ) : null;
+    );
   }
 
 });

--- a/components/social.jsx
+++ b/components/social.jsx
@@ -6,7 +6,8 @@ module.exports = React.createClass({
     var appURL = process.env.APPLICATION_URI;
     var twitterShareURL = 'https://twitter.com/share?url=' + appURL +'/' + this.props.language + '/&text=' + encodeURIComponent(this.getIntlMessage('i_donated_to_mozilla'));
     var facebookShareURL = 'https://www.facebook.com/sharer/sharer.php?u=' + appURL + '/' + this.props.language + '/';
-    return (
+    var shouldDisplay = this.props.shouldDisplay === undefined ? true : this.props.shouldDisplay;
+    return shouldDisplay ? (
       <div className="share-page">
         <div className="container">
           <span className="base-line-thank-you">
@@ -50,7 +51,7 @@ module.exports = React.createClass({
           </span>
         </div>
       </div>
-    );
+    ) : null;
   }
 
 });

--- a/components/social.jsx
+++ b/components/social.jsx
@@ -6,8 +6,7 @@ module.exports = React.createClass({
     var appURL = process.env.APPLICATION_URI;
     var twitterShareURL = 'https://twitter.com/share?url=' + appURL +'/' + this.props.language + '/&text=' + encodeURIComponent(this.getIntlMessage('i_donated_to_mozilla'));
     var facebookShareURL = 'https://www.facebook.com/sharer/sharer.php?u=' + appURL + '/' + this.props.language + '/';
-    var shouldDisplay = this.props.shouldDisplay === undefined ? true : this.props.shouldDisplay;
-    return shouldDisplay ? (
+    return this.props.isHidden ? null : (
       <div className="share-page">
         <div className="container">
           <span className="base-line-thank-you">
@@ -51,7 +50,7 @@ module.exports = React.createClass({
           </span>
         </div>
       </div>
-    ) : null;
+    );
   }
 
 });

--- a/less/new-flow-test/thank-you.less
+++ b/less/new-flow-test/thank-you.less
@@ -82,8 +82,16 @@
   }
 
   .donation-message-text {
-    width:  100%;
-    height: 150px;
+    width:     100%;
+    max-width: 100%;
+    height:    150px;
+  }
+
+  .skip-msg {
+    color:      #27AAE1;
+    margin-top: 10px;
+    text-align: right;
+    cursor:     pointer;
   }
 
   .heart-image,

--- a/less/new-flow-test/thank-you.less
+++ b/less/new-flow-test/thank-you.less
@@ -80,6 +80,12 @@
   h2 {
     font-size: 25px;
   }
+
+  .donation-message-text {
+    width:  100%;
+    height: 150px;
+  }
+
   .heart-image,
   .internet-graphic {
     max-width: none;

--- a/pages/thank-you.jsx
+++ b/pages/thank-you.jsx
@@ -10,6 +10,44 @@ import ThankYouHeader from '../components/thank-you-header.jsx';
 import { FormattedHTMLMessage, IntlMixin } from 'react-intl';
 import analytics from '../assets/js/analytics.js';
 import form from '../scripts/form.js';
+import SubmitButton from '../components/submit-button.jsx';
+
+var DonationMessage = React.createClass({
+  mixins: [IntlMixin, require('../mixins/form.jsx')],
+  propTypes: { name: React.PropTypes.string.isRequired },
+  componentDidMount: function() {
+    analytics();
+  },
+  sendMessage: function() {
+    this.setState({submitting: true});
+    console.log('sending message');
+  },
+  render: function() {
+    var className = "row new-flow-test";
+    if (this.props.test) {
+      className += " " + this.props.test;
+    }
+    return (
+      <div>
+        <div className="container">
+          <div className="row new-flow-thank-you">
+            <h2>Send a message to Mozilla with your gift:</h2>
+            <textarea className="donation-message-text" defaultValue="Tell us how you really feel"></textarea>
+            <SubmitButton
+              submitting={this.state.submitting}
+              validate={[this.props.name]}
+              onSubmit={this.sendMessage}
+              submit={[this.props.name]}
+            >
+            Send Message
+            </SubmitButton>
+          </div>
+          <a className="skip-msg">No thanks.</a>
+        </div>
+      </div>
+    );
+  }
+});
 
 var ThankYou = React.createClass({
   mixins: [IntlMixin],
@@ -20,9 +58,9 @@ var ThankYou = React.createClass({
   render: function() {
     var className = "row new-flow-test";
     var locale = this.props.locales[0];
-    var signUpOrSocial = (<Social language={locale}/>);
+    var signUpOrSocial = (<Social language={locale} shouldDisplay={false} />);
     if (this.props.params && /^(en|de)(\b|$)/.test(locale)) {
-      signUpOrSocial = (<Signup country={this.props.country} email={this.props.email} locales={this.props.locales} />);
+      signUpOrSocial = (<Signup country={this.props.country} email={this.props.email} locales={this.props.locales} shouldDisplay={false} />);
     }
     if (this.props.test) {
       className += " " + this.props.test;
@@ -44,6 +82,7 @@ var ThankYou = React.createClass({
             <ThankYouHeader/>
           </span>
           <div>
+            <DonationMessage name="donationMmessage" locales={this.props.locales} country={this.props.country} />
             {signUpOrSocial}
             <Footer/>
           </div>

--- a/pages/thank-you.jsx
+++ b/pages/thank-you.jsx
@@ -51,6 +51,10 @@ var DonationMessage = React.createClass({
 
 var ThankYou = React.createClass({
   mixins: [IntlMixin],
+  panelPositions: {
+    donationMessage: 0,
+    signUpOrSocial:  1
+  },
   componentDidMount: function() {
     form.updateField("email", this.props.email || "");
     analytics();
@@ -60,9 +64,14 @@ var ThankYou = React.createClass({
   },
   renderSignupOrSocial: function() {
     var locale = this.props.locales[0];
-    var signUpOrSocial = (<Social language={locale} isHidden={this.state.currentPanelPos !== 1}/>);
+    var signUpOrSocial = (<Social language={locale} isHidden={this.state.currentPanelPos !== this.panelPositions.signUpOrSocial}/>);
     if (this.props.params && /^(en|de)(\b|$)/.test(locale)) {
-      signUpOrSocial = (<Signup country={this.props.country} email={this.props.email} locales={this.props.locales} isHidden={this.state.currentPanelPos !== 1}/>);
+      signUpOrSocial = (<Signup
+        country={this.props.country}
+        email={this.props.email}
+        locales={this.props.locales}
+        isHidden={this.state.currentPanelPos !== this.panelPositions.signUpOrSocial}
+      />);
     }
     return signUpOrSocial;
   },
@@ -93,11 +102,11 @@ var ThankYou = React.createClass({
           </span>
           <div>
             <DonationMessage
-              name="donationMmessage"
+              name="donationMessage"
               locales={this.props.locales || []}
               country={this.props.country || ""}
               whenFinished={this.incrementPanelPos}
-              isHidden={this.state.currentPanelPos !== 0}
+              isHidden={this.state.currentPanelPos !== this.panelPositions.donationMessage}
             />
             {this.renderSignupOrSocial()}
             <Footer/>

--- a/pages/thank-you.jsx
+++ b/pages/thank-you.jsx
@@ -20,14 +20,14 @@ var DonationMessage = React.createClass({
   },
   sendMessage: function() {
     this.setState({submitting: true});
-    console.log('sending message');
+    this.props.whenFinished();
   },
   render: function() {
     var className = "row new-flow-test";
     if (this.props.test) {
       className += " " + this.props.test;
     }
-    return (
+    return this.props.isHidden ? null : (
       <div>
         <div className="container">
           <div className="row new-flow-thank-you">
@@ -41,8 +41,8 @@ var DonationMessage = React.createClass({
             >
             Send Message
             </SubmitButton>
+            <div className="skip-msg" onClick={this.props.whenFinished}>No thanks.</div>
           </div>
-          <a className="skip-msg">No thanks.</a>
         </div>
       </div>
     );
@@ -55,13 +55,23 @@ var ThankYou = React.createClass({
     form.updateField("email", this.props.email || "");
     analytics();
   },
+  getInitialState: function() {
+    return {currentPanelPos: 0};
+  },
+  renderSignupOrSocial: function() {
+    var locale = this.props.locales[0];
+    var signUpOrSocial = (<Social language={locale} isHidden={this.state.currentPanelPos !== 1}/>);
+    if (this.props.params && /^(en|de)(\b|$)/.test(locale)) {
+      signUpOrSocial = (<Signup country={this.props.country} email={this.props.email} locales={this.props.locales} isHidden={this.state.currentPanelPos !== 1}/>);
+    }
+    return signUpOrSocial;
+  },
+  incrementPanelPos: function(component) {
+    var nextPos = this.state.currentPanelPos += 1;
+    this.setState({currentPanelPos: nextPos});
+  },
   render: function() {
     var className = "row new-flow-test";
-    var locale = this.props.locales[0];
-    var signUpOrSocial = (<Social language={locale} shouldDisplay={false} />);
-    if (this.props.params && /^(en|de)(\b|$)/.test(locale)) {
-      signUpOrSocial = (<Signup country={this.props.country} email={this.props.email} locales={this.props.locales} shouldDisplay={false} />);
-    }
     if (this.props.test) {
       className += " " + this.props.test;
     }
@@ -82,8 +92,14 @@ var ThankYou = React.createClass({
             <ThankYouHeader/>
           </span>
           <div>
-            <DonationMessage name="donationMmessage" locales={this.props.locales} country={this.props.country} />
-            {signUpOrSocial}
+            <DonationMessage
+              name="donationMmessage"
+              locales={this.props.locales || []}
+              country={this.props.country || ""}
+              whenFinished={this.incrementPanelPos}
+              isHidden={this.state.currentPanelPos !== 0}
+            />
+            {this.renderSignupOrSocial()}
             <Footer/>
           </div>
         </div>


### PR DESCRIPTION
Hey guys, I saw https://github.com/mozilla/donate.mozilla.org/issues/908 on adding a comment feature and thought I'd tackle it. I know it's Bluesky'd, but I figured I'd throw up this quick proof of concept. Is it somewhat along the lines of what you were thinking of? Of course right now there's no route for posting the message, and the tests have not been updated- so functionally it's a stub. I also didn't update the locales but will do so if this gets approved. I'm new to React so let me know if I'm doing something that is against best practices.

The new flow looks like this now:
Donation -> donor message -> email signup. If you don't want to leave a message, you can skip it and you will be taken to the email signup. The donor message is a component and is displayed on the same page as the signup component (thank-you.jsx).

![donor-message](https://cloud.githubusercontent.com/assets/5622404/11997525/f49576b8-aa32-11e5-8c56-9cc1d33f71e8.png)
![email-signup](https://cloud.githubusercontent.com/assets/5622404/11997528/fad8bc56-aa32-11e5-985d-a0b99ecd22a3.png)
