### PR TITLE
Webhook callback for stripe.disputes.created - which automatically closes them

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "good-console-logfmt": "1.0.2",
     "habitat": "3.1.2",
     "hapi": "11.1.4",
+    "hapi-auth-bearer-token": "4.0.2",
     "hatchet": "0.3.2",
     "hoek": "3.0.4",
     "imports-loader": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "karma-sourcemap-loader": "0.3.6",
     "karma-webpack": "1.7.0",
     "mocha": "2.3.4",
+    "moment": "2.12.0",
     "react-test-context": "0.1.0",
     "selenium-webdriver": "2.48.2",
     "should": "8.0.2"

--- a/routes/index.js
+++ b/routes/index.js
@@ -373,7 +373,7 @@ var routes = {
       event.data.object.id,
       function(closeDisputeError, dispute) {
         if (closeDisputeError) {
-          return reply(Boom.badImplementation('An error occurred while closing the dispute', closeDisputeError));
+          return reply(boom.badImplementation('An error occurred while closing the dispute', closeDisputeError));
         }
 
         reply('Dispute closed');

--- a/routes/index.js
+++ b/routes/index.js
@@ -361,6 +361,24 @@ var routes = {
         });
       });
     }
+  },
+  'stripe-dispute': function(request, reply) {
+    var event = request.payload;
+
+    if (event.type !== 'charge.dispute.created') {
+      return reply('This hook only processes newly created disputes');
+    }
+
+    stripe.closeDispute(
+      event.data.object.id,
+      function(closeDisputeError, dispute) {
+        if (closeDisputeError) {
+          return reply(Boom.badImplementation('An error occurred while closing the dispute', closeDisputeError));
+        }
+
+        reply('Dispute closed');
+      }
+    );
   }
 };
 

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -70,5 +70,8 @@ module.exports = {
         });
       }
     );
+  },
+  closeDispute: function(disputeId, callback) {
+    stripe.disputes.close(disputeId, callback);
   }
 };

--- a/sample.env
+++ b/sample.env
@@ -4,6 +4,7 @@ export PORT=3000
 export NPM_CONFIG_PRODUCTION=false
 export STRIPE_PUBLIC_KEY=pk_test_BZ0QTIwe7BVAk1ZDxOgWZ9Z6
 export STRIPE_SECRET_KEY=sk_test_HbsdaR1Bn5I84vdezKa9VcvA
+export STRIPE_WEBHOOK_SECRET=iwYmVFFTDH9hrxCU9n4k4cixeiadYLaJ
 export PAYPAL_USER=receive-donation_api1.test.com
 export PAYPAL_EMAIL=receive-donation@test.com
 export PAYPAL_PWD=783PM8L5UQFWCK87

--- a/scripts/refund_stripe_charges.js
+++ b/scripts/refund_stripe_charges.js
@@ -14,7 +14,7 @@ var before_day_count = process.env.BEFORE_DAY_COUNT || 0;
 var stripe_charge_list_opts = {
   created: {
     gte: moment(Date.now()).subtract(after_day_count, 'days').unix().valueOf(),
-    lte: moment(Date.now()).subtract(before_day_count, 'days').unix().valueOf(),
+    lte: moment(Date.now()).subtract(before_day_count, 'days').unix().valueOf()
   },
   limit: 100,
   expand: ["data.customer"]
@@ -37,11 +37,11 @@ function refund_charge(charge, done) {
 
 var charged_to_email = (charge) => filter_emails.indexOf(charge.customer.email) >= 0;
 
-var charge_was_paid = (charge) => charge.paid
+var charge_was_paid = (charge) => charge.paid;
 
-var charge_not_disputed = (charge) => !charge.dispute
+var charge_not_disputed = (charge) => !charge.dispute;
 
-var charge_not_refunded = (charge) => !charge.refunded
+var charge_not_refunded = (charge) => !charge.refunded;
 
 async.doWhilst(function(done) {
   stripe.charges.list(
@@ -69,7 +69,7 @@ async.doWhilst(function(done) {
       starting_after: charges.data[charges.data.length - 1].id,
       limit: 100,
       expand: ["data.customer"]
-    }
+    };
   }
   return charges.has_more;
 }, function(err) {

--- a/scripts/refund_stripe_charges.js
+++ b/scripts/refund_stripe_charges.js
@@ -1,0 +1,82 @@
+// This script refunds ALL CHARGES related to a given email address.
+// This is necessary to help combat large amounts of fraud.
+
+// Config
+var Habitat = require('habitat');
+Habitat.load();
+
+var stripe = require('stripe')(process.env.STRIPE_API_KEY);
+var async = require('async');
+var moment = require('moment');
+var filter_email = process.env.CUSTOMER_EMAIL;
+var after_day_count = process.env.AFTER_DAY_COUNT || 60;
+var before_day_count = process.env.BEFORE_DAY_COUNT || 0;
+var stripe_charge_list_opts = {
+  created: {
+    gte: moment(Date.now()).subtract(after_day_count, 'days').unix().valueOf(),
+    lte: moment(Date.now()).subtract(before_day_count, 'days').unix().valueOf(),
+  },
+  limit: 100,
+  expand: ["data.customer"]
+};
+
+var charges;
+
+function refund_charge(charge, done) {
+  console.log(`refunding charge ID: ${charge.id}, Amount: ${charge.amount / 100}, currency: ${charge.currency}`);
+  stripe.refunds.create({
+    charge: charge.id,
+    reason: "fraudulent"
+  }, function(err, resp) {
+    if (err) {
+      return done(err);
+    }
+    done();
+  });
+}
+
+var charged_to_email = (charge) => charge.customer.email === filter_email;
+
+var charge_was_paid = (charge) => charge.paid
+
+var charge_not_disputed = (charge) => !charge.dispute
+
+var charge_not_refunded = (charge) => !charge.refunded
+
+async.doWhilst(function(done) {
+  stripe.charges.list(
+    stripe_charge_list_opts,
+    function(err, resp) {
+      if (err) {
+        return done(err);
+      }
+      charges = resp;
+      async.eachSeries(
+        charges.data
+          .filter(charged_to_email)
+          .filter(charge_was_paid)
+          .filter(charge_not_disputed)
+          .filter(charge_not_refunded),
+        refund_charge,
+        done
+      );
+    }
+  );
+}, function() {
+  if (charges.has_more) {
+    console.log('Fetching next page of charges...');
+    stripe_charge_list_opts = {
+      starting_after: charges.data[charges.data.length - 1].id,
+      limit: 100,
+      expand: ["data.customer"]
+    }
+  }
+  return charges.has_more;
+}, function(err) {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log('Done!');
+  process.exit(0);
+});

--- a/scripts/refund_stripe_charges.js
+++ b/scripts/refund_stripe_charges.js
@@ -8,7 +8,7 @@ Habitat.load();
 var stripe = require('stripe')(process.env.STRIPE_API_KEY);
 var async = require('async');
 var moment = require('moment');
-var filter_email = process.env.CUSTOMER_EMAIL;
+var filter_emails = process.env.CUSTOMER_EMAIL.split(',');
 var after_day_count = process.env.AFTER_DAY_COUNT || 60;
 var before_day_count = process.env.BEFORE_DAY_COUNT || 0;
 var stripe_charge_list_opts = {
@@ -35,7 +35,7 @@ function refund_charge(charge, done) {
   });
 }
 
-var charged_to_email = (charge) => charge.customer.email === filter_email;
+var charged_to_email = (charge) => filter_email.indexOf(charge.customer.email) >= 0;
 
 var charge_was_paid = (charge) => charge.paid
 

--- a/scripts/refund_stripe_charges.js
+++ b/scripts/refund_stripe_charges.js
@@ -35,7 +35,7 @@ function refund_charge(charge, done) {
   });
 }
 
-var charged_to_email = (charge) => filter_email.indexOf(charge.customer.email) >= 0;
+var charged_to_email = (charge) => filter_emails.indexOf(charge.customer.email) >= 0;
 
 var charge_was_paid = (charge) => charge.paid
 

--- a/server.js
+++ b/server.js
@@ -75,7 +75,6 @@ module.exports = function(options) {
 
   server.auth.strategy("stripe", "bearer-access-token", {
     validateFunc: function(token, callback) {
-      // this = request
       callback(null, token === process.env.STRIPE_WEBHOOK_SECRET, { token: token });
     }
   });

--- a/server.js
+++ b/server.js
@@ -71,6 +71,15 @@ module.exports = function(options) {
     uri: process.env.APPLICATION_URI
   });
 
+  server.register(require("hapi-auth-bearer-token"), function(err) {});
+
+  server.auth.strategy("stripe", "bearer-access-token", {
+    validateFunc: function(token, callback) {
+      // this = request
+      callback(null, token === process.env.STRIPE_WEBHOOK_SECRET, { token: token });
+    }
+  });
+
   server.route([
     {
       method: 'POST',
@@ -244,6 +253,13 @@ module.exports = function(options) {
           privacy: 'public'
         }
       }
+    }, {
+      method: "POST",
+      path: "/stripe/dispute-callback",
+      config: {
+        auth: "stripe"
+      },
+      handler: routes['stripe-dispute']
     }
   ]);
 
@@ -335,4 +351,3 @@ module.exports = function(options) {
 
   return server;
 };
-

--- a/server.js
+++ b/server.js
@@ -71,7 +71,11 @@ module.exports = function(options) {
     uri: process.env.APPLICATION_URI
   });
 
-  server.register(require("hapi-auth-bearer-token"), function(err) {});
+  server.register(require("hapi-auth-bearer-token"), function(err) {
+    if (err) {
+      throw err;
+    }
+  });
 
   server.auth.strategy("stripe", "bearer-access-token", {
     validateFunc: function(token, callback) {


### PR DESCRIPTION
This patch adds a webhook callback, protected by a token, that stripe can hit when a dispute is created. The callback will close the dispute automatically.

@alicoding r?