### PR TITLE
Add a warning about string length for tweets

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -110,8 +110,12 @@ we_are_working_hard=We are working hard to protect the open Web. We want to keep
 dont_miss_news=Don't miss important news about the work your donation makes possible.
 denotes_required_field=denotes required field
 share_a_link_with_your_fellowers=Share a link with your followers
+
+# Used in a tweet, please keep below 116 characters
 i_donated_to_mozilla=I donated to @mozilla today because I #lovetheweb. Join me and help build + protect the Web forever
+# Used in a tweet, please keep below 116 characters
 i_donated_to_thunderbird=I donated to @mozthunderbird today to #freetheinbox. Join me to support communication privacy.
+
 we_include_you=We want to include you in our work!
 # These are the variants:
 get_important_news=Get important news and updates


### PR DESCRIPTION
Several locales are over limits, will warn them, but adding this as well