### PR TITLE
Removing more unused strings

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -1,131 +1,104 @@
+# NOTE: strings for https://donate.mozilla.org. Staging server: https://donate.mofostaging.net
+
+# Donate Bitcoin page
+help_protect_the_web=Help protect the open Web.
+donate_butcoins=Donate Bitcoins
+donation_notice_bitcoin=The Mozilla Foundation is a California non-profit corporation exempt from United States federal income taxation under IRC 501(c)(3) and a public charity classified under IRC sections 170(b)(1)(A) and 509(a)(1). Bitcoin donations Mozilla receives are considered charitable contributions under U.S. federal tax laws, to be used in its discretion for its charitable purposes. If you have questions, check out <a href="https://wiki.mozilla.org/Donate">our FAQ</a> or contact us at <a href="mailto:donate@mozilla.org">donate@mozilla.org</a>.
+
+# Site title
+give_to_mozilla=Give to Mozilla Today
+
+# Logo alt text
+donate_to_mozilla=Donate to Mozilla
+donate_to_thunderbird=Donate to Thunderbird
+
+# Donation description
+mozilla_donation=Mozilla Foundation Donation
+mozilla_monthly_donation=Mozilla Foundation Monthly Donation
+
+# Homepage
+donate_now=Donate now
+other_amount=Other amount
 one_time=One time
+monthly=Monthly
+choose_payment=Choose Payment
+secure=Secure
+please_select_an_amount=Please select an amount
+donation_min_error=Donations must be {minAmount} or more
+try_again_later=Something seems to have gone wrong. Please try again later
+other_amount_format_error=Please enter a number up to 2 decimal places.
+credit_card=Credit / debit card
+submitting=Submitting…
+
+# privacy policy variants
+privacy_policy_var_a=We care about privacy and about helping you make informed choices. We want you to understand that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
+privacy_policy_var_c=By making a donation, you acknowledge that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or by <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a> in accordance with their privacy policies, and a record of your donation will be stored by <a href="https://www.mozilla.org/privacy/">Mozilla</a>.
+
+# {bitcoinLink} will be replaced with "Bitcoin" string / {checkLink} will be replaced with "check" string
+other_way_to_give=Other ways to give: {bitcoinLink} | {checkLink}
+Bitcoin=Bitcoin
+check=Check
+problems_donating=Problems donating? <a href="https://wiki.mozilla.org/Donate" target="_blank">Visit our FAQ</a> for answers to most common questions. Still have problems? <a href="mailto:donate@mozilla.org">Send us an email</a>.
+problems_donating_thunderbird=Problems donating? <a href="https://wiki.mozilla.org/Thunderbird/Donate" target="_blank">Visit our FAQ</a> for answers to most common questions. Still have problems? <a href="mailto:thunderbird-donate@mozilla.org">Send us an email</a>.
+donation_notice=Contributions go to the Mozilla Foundation, a 501(c)(3) organization, to be used in its discretion for its charitable purposes. They are tax-deductible in the U.S. to the fullest extent permitted by law.
+donation_notice_thunderbird=Contributions go to the Mozilla Foundation, a 501(c)(3) organization, to support Mozilla Thunderbird.
+
+# Footer
+footerLicense=Portions of this content are &copy;1998&ndash;2015 by individual mozilla.org contributors. Content available under a <a href="https://www.mozilla.org/foundation/licensing/website-content/" target="_blank">Creative Commons license</a>.
+firefox_footer=Mozilla is the non-profit organization behind Firefox.
+firefox_thunderbird_footer=Mozilla is the non-profit organization behind Thunderbird and Firefox.
+Mission=Mission
+About=About
+Contact=Contact
+privacyPolicyFooter=Privacy Policy
+legalNotices=Legal Notices
+
+# About page
+additional_info=We are proudly non-profit, non-corporate and non-compromised. Thousands of people like you help us stand up for an open Web for all. We rely on donations to carry out our mission to keep the Web open and free. Will you give today?
+additional_info_thunderbird=We're the leading open source cross-platform email and calendaring client, free for business and personal use. By donating you'll help ensure it stays that way and contribute towards future development. Will you give today?
+
+# Paypal donate page
+select_donation=Select your donation amount
+
+# Share + sign up page header
 from_all_of_us_at_mozilla=From all of us at Mozilla
 from_all_of_us_at_thunderbird=From the Thunderbird team
-thank_you_for_your_donation=<em>Thank you</em> for your donation
-monthly=Monthly
-please_select_an_amount=Please select an amount
-other_amount=Other amount
-secure=Secure
-credit_card=Credit / debit card
-this_is_required=This is required
+thank_you=Thank you
+from_all_of_us_with_ty_name=From all of us at Mozilla,<br> <b>thank you {name}!</b>
+
+# Sign up page
+working_hard_to_protect_the_web=We're working hard to protect the open web. We want to keep you in the loop!
+sign_up_thunderbird=We're working hard to protect your inbox. Sign up to receive email messages concerning Thunderbird, including updates and requests for feedback.
+email=Email
+email_invalid=Please make sure you have entered a valid email address.
+please_complete=Oops, please complete fields highlighted in red
+pp_acknowledge=To submit this form you must agree with our privacy policy
+privacy_policy=I’m okay with Mozilla handling my info as explained in <a href="https://www.mozilla.org/privacy/" target="_blank">this Privacy Policy</a>.
+privacy_policy_thunderbird=I'm okay with Thunderbird handling my info as explained in <a href="https://www.mozilla.org/privacy/" target="_blank">this Privacy Policy</a>.
+sign_up_now=Sign up now
+
+# Share page
+share=Share
+tell_your_friends=Tell your friends!
+help_spread_the_word=We need your help to spread the word.
+i_donated_to_mozilla=I donated to @mozilla today because I #lovetheweb. Join me and help build + protect the Web forever
+i_donated_to_thunderbird=I donated to @mozthunderbird today to #freetheinbox. Join me to support communication privacy.
+
+# Site title when shared on Facebook
+support_mozilla=Support Mozilla
+
+
+# Legacy strings
 first_name=First name
 last_name=Last name
 address=Address
 city=City
-footerLicense=Portions of this content are &copy;1998&ndash;2015 by individual mozilla.org contributors. Content available under a <a href="https://www.mozilla.org/foundation/licensing/website-content/" target="_blank">Creative Commons license</a>.
+country=Country
 postal_code=Zip/Postal code
 state_province=State/Province
-credit_card_number=Credit card number
-MM=MM
-YY=YY
-CVC=CVC
-Mission=Mission
-About=About
-privacyPolicyFooter=Privacy Policy
-legalNotices=Legal Notices
-Contact=Contact
-donate_butcoins=Donate Bitcoins
-other_way_to_give=Other ways to give: {bitcoinLink} | {checkLink}
-check=Check
-give_to_mozilla=Give to Mozilla Today
-sign_up_now=Sign up now
-your_email=youremail@example.com
-sign_up_for_email=Sign up for email updates
-dont_miss_important_news=Don't miss important news about the work your donation makes possible.
-cvc_info=You can find your three-digit CVC number on the back of your credit card
-credit_card_expiration_month=Credit Card Expiration Month
-credit_card_expiration_year=Credit Card Expiration Year
-email_info=We&rsquo;ll email you a receipt for your donation. We won&rsquo;t send you other email without your permission.
-pp_acknowledge=To submit this form you must agree with our privacy policy
-privacy_policy=I’m okay with Mozilla handling my info as explained in <a href="https://www.mozilla.org/privacy/" target="_blank">this Privacy Policy</a>.
-privacy_policy_thunderbird=I'm okay with Thunderbird handling my info as explained in <a href="https://www.mozilla.org/privacy/" target="_blank">this Privacy Policy</a>.
-please_complete=Oops, please complete fields highlighted in red
-problems_donating=Problems donating? <a href="https://wiki.mozilla.org/Donate" target="_blank">Visit our FAQ</a> for answers to most common questions. Still have problems? <a href="mailto:donate@mozilla.org">Send us an email</a>.
-problems_donating_thunderbird=Problems donating? <a href="https://wiki.mozilla.org/Thunderbird/Donate" target="_blank">Visit our FAQ</a> for answers to most common questions. Still have problems? <a href="mailto:thunderbird-donate@mozilla.org">Send us an email</a>.
-donate_now=Donate now
-donate_monthly=Donate monthly
-donation_notice=Contributions go to the Mozilla Foundation, a 501(c)(3) organization, to be used in its discretion for its charitable purposes. They are tax-deductible in the U.S. to the fullest extent permitted by law.
-donation_notice_thunderbird=Contributions go to the Mozilla Foundation, a 501(c)(3) organization, to support Mozilla Thunderbird.
-stripe_notice=We use Stripe for credit card processing. For more information see their <a href="https://stripe.com/privacy/" target="_blank">Privacy Policy</a>.
-amount=Amount
-support_mozilla=Support Mozilla
-email=Email
-payment=Payment
-choose_payment=Choose Payment
-country=Country
-none=None
-donation_min_error=Donations must be {minAmount} or more
-submitting=Submitting…
-something_went_wrong_with_your_transaction_please_try_again_later=Something went wrong with your transaction. Please try again later
-try_again_later=Something seems to have gone wrong. Please try again later
-gone_wrong_try_another=Something seems to have gone wrong. Please verify your card details or try another card
-expired_card=Sorry, your card has expired. Please verify your card details or try another card
-invalid_CVC=Invalid CVC number
-invalid_expiry_year=Invalid expiration year
-invalid_expiry_month=Invalid expiration month
-incorrect_CVC=Incorrect CVC number
-invalid_number=Invalid credit card number
-incorrect_number=Incorrect credit card number
-invalid_zip=Invalid zip/postal code
-fraud_card=Sorry, your transaction was flagged for fraud protection. Please try another card
-declined_card=Sorry, your card was declined. Please verify your card details or try another card
-transaction_try_another=Something went wrong with your transaction. Please verify your card details or try another card
-dupe_donation=Looks like we already have your donation—please refresh if you wish to donate again
-select_your_amount=Select your amount
-next=Next
-personal=Personal
-other_amount_format_error=Please enter a number up to 2 decimal places.
-donate_today=Donate Today
-select_donation=Select your donation amount
-share=Share
-tell_your_friends=Tell your friends!
-help_spread_the_word=We need your help to spread the word.
-continue=continue
+
+# donate-button.js
 donate_now_amount=Donate { donationAmount } now
-mozilla_donation=Mozilla Foundation Donation
-mozilla_monthly_donation=Mozilla Foundation Monthly Donation
-help_protect_the_web=Help protect the open Web.
-Bitcoin=Bitcoin
-donation_notice_bitcoin=The Mozilla Foundation is a California non-profit corporation exempt from United States federal income taxation under IRC 501(c)(3) and a public charity classified under IRC sections 170(b)(1)(A) and 509(a)(1). Bitcoin donations Mozilla receives are considered charitable contributions under U.S. federal tax laws, to be used in its discretion for its charitable purposes. If you have questions, check out <a href="https://wiki.mozilla.org/Donate">our FAQ</a> or contact us at <a href="mailto:donate@mozilla.org">donate@mozilla.org</a>.
-email_invalid=Please make sure you have entered a valid email address.
-firefox_footer=Mozilla is the non-profit organization behind Firefox.
-firefox_thunderbird_footer=Mozilla is the non-profit organization behind Thunderbird and Firefox.
-donate_to_mozilla=Donate to Mozilla
-donate_to_thunderbird=Donate to Thunderbird
-additional_info=We are proudly non-profit, non-corporate and non-compromised. Thousands of people like you help us stand up for an open Web for all. We rely on donations to carry out our mission to keep the Web open and free. Will you give today?
-additional_info_thunderbird=We're the leading open source cross-platform email and calendaring client, free for business and personal use. By donating you'll help ensure it stays that way and contribute towards future development. Will you give today?
 
-# some of these strings are not or will on the page, or some of them will be use for email/snippets only
-this_really_help_us=This really helps us!
-yes_i_want_to_know_more=Yes, I want to know more!
-yes_i_want_to_keep_in_touch=Yes, I want to keep in touch!
-amount_monthly={amount} monthly
-donate_amount_monthly=Donate {amount} monthly
-from_all_of_us_with_ty_name=From all of us at Mozilla,<br> <b>thank you {name}!</b>
-working_hard_to_protect_the_web=We're working hard to protect the open web. We want to keep you in the loop!
-sign_up_thunderbird=We're working hard to protect your inbox. Sign up to receive email messages concerning Thunderbird, including updates and requests for feedback.
-weekly=Weekly
-thank_you=Thank you
-we_are_working_hard=We are working hard to protect the open Web. We want to keep you updated
-dont_miss_news=Don't miss important news about the work your donation makes possible.
-denotes_required_field=denotes required field
-share_a_link_with_your_fellowers=Share a link with your followers
-i_donated_to_mozilla=I donated to @mozilla today because I #lovetheweb. Join me and help build + protect the Web forever
-i_donated_to_thunderbird=I donated to @mozthunderbird today to #freetheinbox. Join me to support communication privacy.
-we_include_you=We want to include you in our work!
-# These are the variants:
-get_important_news=Get important news and updates
-please_allow_us_in_touch=Please allow us to keep in touch
-stay_informed=We want you to stay informed
-help_reach_you=This helps us reach you
-can_reach_you=This means we can reach you
-dont_miss_updates=Don't miss updates
-
-# popup further monthly ask
-h1_popup_further_monlth=Before we process your donation, will you consider stretching your contribution by converting it to a monthly gift of {amount}?
-popup_answer_yes=<b>Yes!</b> — Convert my one-time gift to an automatic monthly donation of {newAmount}
-popup_answer_no=<b>No thanks</b> — please continue with my one-time gift of {amount}
-
-# privacy policy varients
-privacy_policy_var_a=We care about privacy and about helping you make informed choices. We want you to understand that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
-privacy_policy_var_c=By making a donation, you acknowledge that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or by <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a> in accordance with their privacy policies, and a record of your donation will be stored by <a href="https://www.mozilla.org/privacy/">Mozilla</a>.
+# mixins/form.js
+donate_monthly=Donate monthly

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -81,7 +81,9 @@ sign_up_now=Sign up now
 share=Share
 tell_your_friends=Tell your friends!
 help_spread_the_word=We need your help to spread the word.
+# Used in a tweet, please keep below 116 characters
 i_donated_to_mozilla=I donated to @mozilla today because I #lovetheweb. Join me and help build + protect the Web forever
+# Used in a tweet, please keep below 116 characters
 i_donated_to_thunderbird=I donated to @mozthunderbird today to #freetheinbox. Join me to support communication privacy.
 
 # Site title when shared on Facebook


### PR DESCRIPTION
Removing a bunch of strings that are not used in any template (ran `ack string_id` in src folder, I guess that’s enough?)

I’ve left some strings at the bottom of the file (L91-L104) that are still used in templates, but they don’t seem exposed anywhere. @ScottDowne let me know if it’s safe to remove them as well.

I also reorganized the file, grouping strings per page and sorting them in the same way they are displayed on the page. This will be easier for localizers to understand the context and find the strings for testing. I’ve also added a few comments.