### PR TITLE
Fix disclaimers style on /about + Safari style issues

### DIFF
--- a/less/components/payment-buttons.less
+++ b/less/components/payment-buttons.less
@@ -16,7 +16,7 @@
     font-size: 13px;
   }
   .row.medium-label-size.donate-button {
-    font-weight: 900;
+    font-weight: 600;
     font-size: 16px;
   }
 }

--- a/less/components/submit-button.less
+++ b/less/components/submit-button.less
@@ -13,7 +13,6 @@
     cursor: pointer;
     border: 1px solid transparent;
     line-height: 1.42857;
-    line-weight: 800;
     padding: 3px 5px 7px;
     -moz-user-select: none;
     color: #fff;

--- a/less/pages/additional-info.less
+++ b/less/pages/additional-info.less
@@ -36,7 +36,7 @@
   }
   .footer {
     max-width: 420px;
-    padding: 0 5px;
+    padding: 0 15px;
     .half {
       width: 75%;
       padding-right: 35px;
@@ -45,23 +45,22 @@
   }
   .footer,
   .disclaimers {
-    max-width: 420px;
     margin: 30px auto 0;
   }
   .disclaimers {
+    background-color: #CECCCA;
+    border-radius: 6px;
+    padding: 0 20px;
+  }
+  .disclaimers {
     text-align: left;
-    padding: 0;
-    max-width: 840px;
-    background: transparent;
+    max-width: 420px;
     .other-ways-to-give,
     .need-help,
     .donation-notice,
     .stripe-notice {
       width: 100%;
-      max-width: 420px;
       text-align: left;
-      padding-left: 10px;
-      padding-right: 10px;
       margin-left: auto;
     }
   }
@@ -72,22 +71,22 @@
     }
     .footer {
       width: 100%;
-      padding: 0px 25px;
+      max-width: 840px;
+      padding: 0 25px;
     }
     .additional-page {
       min-height: 481px;
     }
-    .footer,
     .disclaimers {
       max-width: 840px;
+      padding: 0 30px;
     }
     .disclaimers {
       .other-ways-to-give,
       .need-help,
       .donation-notice,
       .stripe-notice {
-        max-width: 530px;
-        padding-left: 30px;
+        max-width: 840px;
         margin-left: 0;
       }
     }

--- a/less/pages/additional-info.less
+++ b/less/pages/additional-info.less
@@ -11,6 +11,7 @@
     }
     .container {
       display: inline-block;
+      vertical-align: top;
       text-align: left;
       padding: 30px;
     }

--- a/less/pages/faq.less
+++ b/less/pages/faq.less
@@ -52,7 +52,7 @@
       margin: 35px 0 0 0;
       transition: background-color .15s,color .15s;
       color: #FFFFFF;
-      font-weight: 800;
+      font-weight: 600;
       text-decoration: none;
       &:hover {
         background-color: #FFFFFF;

--- a/less/shared.less
+++ b/less/shared.less
@@ -476,7 +476,7 @@ i.fa.hint {
 #secure-label {
   margin: 4px 0;
   font-size: 15px;
-  font-weight: 800;
+  font-weight: 600;
   color: #D0D0D0;
   text-transform: uppercase;
   letter-spacing: 0.1px;


### PR DESCRIPTION
This fixes the disclaimer on /about, mainly backporting changes done on the homepage. Does that look good to you @beccaklam ? I’ve tested smaller screen sizes too, but feel free to double check

Before:
![capture d ecran - 2016-12-16 a 14 47 38](https://cloud.githubusercontent.com/assets/1294206/21266677/17fcb9dc-c39f-11e6-8a43-20fa008bb8d5.png)

After:
![capture d ecran - 2016-12-16 a 14 47 51](https://cloud.githubusercontent.com/assets/1294206/21266674/12e89d94-c39f-11e6-9ab8-c6788ae12b5b.png)
