### PR TITLE
Some currencies are cut-off in the dropdown when selected

### DIFF
--- a/less/components/currency-dropdown.less
+++ b/less/components/currency-dropdown.less
@@ -2,7 +2,7 @@
   font-size: 14px;
   text-transform: uppercase;
   text-align: center;
-  padding: 0 20px;
+  padding: 0;
   margin-left: 5px;
   display: inline-block;
   width: 120px;


### PR DESCRIPTION
Looks like we should set the padding to 0px.
Current:
<img width="139" alt="capture d ecran 2016-12-19 a 11 27 37" src="https://cloud.githubusercontent.com/assets/1294206/21309460/c3f99890-c5de-11e6-9b7c-ab1858825339.png">

Fixed:
<img width="140" alt="capture d ecran 2016-12-19 a 11 27 49" src="https://cloud.githubusercontent.com/assets/1294206/21309453/c055e0d6-c5de-11e6-8a90-31e93ec8ee1b.png">
