### PR TITLE
Improve Hapi shutdown procedure

### DIFF
--- a/start.js
+++ b/start.js
@@ -10,8 +10,12 @@ function start() {
   });
 
   var shutdown = () => {
-    server.stop(() => {
-      process.exit(0);
+    server.stop({
+      timeout: 15000 // wait fifteen seconds before forcefully terminating existing connections
+    },() => {
+      setTimeout(() => {
+        process.exit(0);
+      }, 15000);
     });
   };
 

--- a/start.js
+++ b/start.js
@@ -10,9 +10,13 @@ function start() {
   });
 
   var shutdown = () => {
+    // instruct hapi to stop accepting incoming requests, and to 
+    // wait fifteen seconds before forcefully terminating existing connections.
+    // We do this so that we don't interrupt in-flight and queued requests
     server.stop({
-      timeout: 15000 // wait fifteen seconds before forcefully terminating existing connections
+      timeout: 15000
     },() => {
+      // wait fifteen seconds before terminating the process (to allow for the existing request timeout to run it's course)
       setTimeout(() => {
         process.exit(0);
       }, 15000);


### PR DESCRIPTION
When Heroku sends a SIGTERM to the app, hapi would immediately kill every process, causing in-flight requests to never get completed.

This patch allows open connections to complete within fifteen seconds, and sets a timeout for killing the process. Fifteen seconds is half the time that we're allowed by Heroku before it forcefully shuts things down, so everything should be just fine from now on.

edit: 

for reference: https://hapijs.com/api/13.3.0#serverstopoptions-callback