### PR TITLE
Fix margin with payment buttons for long locales

### DIFF
--- a/less/shared.less
+++ b/less/shared.less
@@ -469,11 +469,12 @@ i.fa.hint {
 }
 
 .choose-payment {
+  margin-bottom: 0;
   margin-right: 5px;
 }
 
 #secure-label {
-  margin: 4px 0;
+  margin: 4px 0 20px 0;
   font-size: 15px;
   font-weight: 600;
   color: #D0D0D0;


### PR DESCRIPTION
I’m moving the margin on the buttons themselves, because it doesn’t work when the "SECURE" element is wrapping.

Before:
<img width="434" alt="capture d ecran 2016-12-23 a 17 21 24" src="https://cloud.githubusercontent.com/assets/1294206/21458193/cda946c0-c934-11e6-9048-d430dd26b89d.png">

After:
<img width="430" alt="capture d ecran 2016-12-23 a 17 21 03" src="https://cloud.githubusercontent.com/assets/1294206/21458195/d16c8e8e-c934-11e6-8f0e-d83a77bd8310.png">
