### PR TITLE
Implementing winner from payment button testing

### DIFF
--- a/less/components/payment-buttons.less
+++ b/less/components/payment-buttons.less
@@ -22,6 +22,9 @@
 .paypal-disabled {
   .credit-card-logos {
     background-position:-2px -33px,50%;
+    &.no-amex {
+      background-position: -33px -36px;
+    }
   }
 }
 
@@ -92,6 +95,9 @@ label.payment-cc-label {
   .paypal-disabled {
     .credit-card-logos {
       background-position:-2px -55px,50%;
+      &.no-amex {
+        background-position: -47px -55px, 50%;
+      }
     }
   }
 

--- a/less/components/payment-buttons.less
+++ b/less/components/payment-buttons.less
@@ -11,73 +11,51 @@
   }
 }
 
-.payment-cc-label, .payment-paypal-label {
-  .row.medium-label-size {
-    font-size: 13px;
-  }
-  .row.medium-label-size.donate-button {
-    font-weight: 600;
-    font-size: 16px;
+
+.credit-card-logos {
+  background-position: center -3px;
+  &.no-amex {
+    background-position: -33px -3px, 50%;
   }
 }
 
-.credit-card-logos {
-  background-position: center -36px;
-  &.no-amex {
-    background-position: -33px -36px;
+.paypal-disabled {
+  .credit-card-logos {
+    background-position:-2px -33px,50%;
   }
-    margin: -7px auto -6px;
 }
 
 .paypal-logo {
-  background-position: center -104px;
-  margin: -11px auto -3px;
+  background-position: center -70px;
+  margin: -8px auto -5px;
 }
 
 input.payment-type + label {
-  background-color: #EBEBEB;
+  background-color: #49AFFD;
+  color: white;
   background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.1));
-  color: #65656D;
 }
 
 input.payment-type + label:hover {
-  background-color: #F2F2F2;
-  // This is needed to override the baseline background.
-  background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.1));
-}
-input.payment-type + label:hover {
-  // This is needed to override the baseline background.
-  background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.1));
+  background-color: #75baef;
 }
 
 input.payment-type:checked + label {
-  background-color: #49AFFD;
+  background-color: #0390FC;
   color: white;
   background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.2));
 }
 
 label.payment-paypal-label,
 label.payment-cc-label {
-  height: 89px;
+  height: 79px;
 }
 
-label.payment-cc-label:hover .payment-logos {
-  background-position: center -36px;
-  &.no-amex {
-    background-position: -33px -36px;
-  }
-}
-label.payment-paypal-label:hover .payment-logos {
-  background-position: center -104px;
-  &.no-amex {
-    background-position: -33px -104px;
-  }
-}
 .payment-cc-input:checked + .payment-cc-label {
   .credit-card-logos {
     background-position: center -3px;
     &.no-amex {
-      background-position: -33px -3px;
+      background-position: -33px -3px, 50%;
     }
   }
 }
@@ -85,11 +63,11 @@ label.payment-paypal-label:hover .payment-logos {
 .payment-paypal-input:checked + .payment-paypal-label {
   .paypal-logo {
     background-position: center -70px;
-    color: white;
   }
 }
 
 @media screen and (min-width: 480px) {
+
   .payment-logos {
     width: 165px;
     height: 45px;
@@ -98,35 +76,35 @@ label.payment-paypal-label:hover .payment-logos {
       width: 108px;
     }
   }
+
+  label.payment-paypal-label,
+  label.payment-cc-label {
+    height: 89px;
+  }
+
   .credit-card-logos {
-    background-position: -2px -55px, center;
+    background-position: center -3px;
     &.no-amex {
-      background-position: -47px -55px, center;
+        background-position: -47px -5px, 50%;
     }
   }
 
-  label.payment-cc-label:hover .payment-logos {
-    background-position: -2px -55px, center;
-    &.no-amex {
-      background-position: -47px -55px, center;
+  .paypal-disabled {
+    .credit-card-logos {
+      background-position:-2px -55px,50%;
     }
   }
+
   .paypal-logo {
-    background-position: -4px -160px, center;
-  }
-
-  label.payment-paypal-label:hover .payment-logos {
-    background-position: -4px -160px, center;
-    &.no-amex {
-      background-position: -47px -160px, center;
-    }
+    background-position: -6px -111px, center;
+    margin:auto;
   }
 
   .payment-cc-input:checked + .payment-cc-label {
     .credit-card-logos {
-      background-position: -4px -5px, center;
+      background-position: center -3px;
       &.no-amex {
-        background-position: -47px -5px, center;
+        background-position: -47px -5px, 50%;
       }
     }
   }
@@ -136,115 +114,4 @@ label.payment-paypal-label:hover .payment-logos {
       background-position: -6px -111px, center;
     }
   }
-
-  .paypal-logo {
-    margin: -7px auto -8px;
-  }
-
-  .credit-card-logos {
-    margin: -12px auto -3px;
-  }
-
-}
-
-.donate-button-text {
-  .donate-button {
-    display: none;
-  }
-  .payment-logos {
-    margin: 0 auto;
-  }
-  .payment-cc-label, .payment-paypal-label {
-    .row.medium-label-size {
-      font-size: 16px;
-    }
-  }
-}
-
-.donate-buttons-blue {
-  //Position so that cc logos are white even on initial load
-  input.payment-type + label {
-    background-color: #49AFFD;
-    color: white;
-    .credit-card-logos {
-      background-position: center -3px;
-      &.no-amex {
-        background-position: -33px -3px;
-      }
-      margin: -6px auto -7px;
-    }
-    //Position so that the paypal logos is white even on initial load
-    .paypal-logo {
-      background-position: center -70px;
-      margin: -8px auto -5px;
-    }
-  }
-
-  input.payment-type + label:hover {
-    background-color: #75baef;
-  }
-
-  input.payment-type:checked + label {
-    background-color: #0390FC;
-    background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.2));
-  }
-
-  .payment-cc-input:checked + .payment-cc-label {
-    .credit-card-logos {
-      background-position: center -3px;
-      &.no-amex {
-        background-position: -33px -3px;
-      }
-    }
-  }
-
-  @media screen and (min-width: 480px) {
-
-    input.payment-type + label {
-      background-color: #49AFFD;
-      color: white;
-      .credit-card-logos {
-        background-position: center -3px;
-        &.no-amex {
-          background-position: -47px -3px;
-        }
-        margin: -12px auto 0;
-      }
-      .paypal-logo {
-        background-position: -6px -111px, center;
-        margin: -7px auto -8px;
-      }
-    }
-
-  }
-
-}
-
-.buttons-less-text {
-
-  .less-text {
-    display: none;
-  }
-
-  .credit-card-logos {
-    margin: auto;
-  }
-
-  .paypal-logo {
-    margin: auto;
-  }
-
-  @media screen and (min-width: 480px) {
-
-    input.payment-type + label {
-      .credit-card-logos {
-        margin: auto;
-      }
-      .paypal-logo {
-        margin: auto;
-      }
-    }
-
-  }
-
 }

--- a/less/components/payment-buttons.less
+++ b/less/components/payment-buttons.less
@@ -115,3 +115,7 @@ label.payment-cc-label {
     }
   }
 }
+
+.less-text {
+  display:none;
+}

--- a/less/pages/thunderbird.less
+++ b/less/pages/thunderbird.less
@@ -31,30 +31,6 @@
       background-color: #53A0F0;
     }
   }
-  .payment-type + label,
-  input[name="donation_amount"] + label {
-    color: #333333;
-    background: #EAEFF2;
-    transition: all .3s ease 0s;
-    &:before {
-      display: none;
-    }
-    &:hover {
-      background: #43A6E2;
-      color: #fff;
-      .credit-card-logos {
-        background-position: -4px -5px, center;
-      }
-      .paypal-logo {
-        background-position: -6px -111px,center;
-      }
-    }
-  }
-  .payment-type:checked + label,
-  input[name="donation_amount"]:checked + label {
-    background: #277AC1;
-    color: #fff;
-  }
   .disclaimers {
     padding: 0 5px;
     margin: 0 auto;

--- a/src/components/payment-options.js
+++ b/src/components/payment-options.js
@@ -37,6 +37,7 @@ var PayPalButton = React.createClass({
         <div className="row payment-logos paypal-logo">
           <p>&nbsp;</p>
         </div>
+        <div className="row medium-label-size less-text">PayPal</div>
       </span>
     );
   },
@@ -93,6 +94,7 @@ var StripeButton = React.createClass({
           <div className={className}>
             <p>&nbsp;</p>
           </div>
+          <div className="row medium-label-size less-text">{this.context.intl.formatMessage({id: 'credit_card'})}</div>
         </label>
       </div>
     );

--- a/src/components/payment-options.js
+++ b/src/components/payment-options.js
@@ -37,7 +37,6 @@ var PayPalButton = React.createClass({
         <div className="row payment-logos paypal-logo">
           <p>&nbsp;</p>
         </div>
-        <div className="row medium-label-size less-text">PayPal</div>
       </span>
     );
   },
@@ -94,7 +93,6 @@ var StripeButton = React.createClass({
           <div className={className}>
             <p>&nbsp;</p>
           </div>
-          <div className="row medium-label-size less-text">{this.context.intl.formatMessage({id: 'credit_card'})}</div>
         </label>
       </div>
     );


### PR DESCRIPTION
Hey @ScottDowne, the results from the payment button test came through and, as per the chart below, simplified blue buttons won, improving conversion rate by 7.8%. I implemented those changes and also removed old tests from the payment-options.less file. Please let me know if you have any questions or concerns.

<img width="1137" alt="image" src="https://cloud.githubusercontent.com/assets/20688240/21459055/1bfe2394-c8f0-11e6-81b2-6db6f20a6b88.png">


cc @HPaulJohnson
