### PR TITLE
Removing dead variable.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -90,7 +90,6 @@ var routes = {
       var stripe_customer_create_service = customerData.stripe_customer_create_service;
       var customer;
       var badRequest;
-      var basketData;
 
       if (err) {
         badRequest = boom.badRequest('Stripe charge failed');


### PR DESCRIPTION
@cadecairos Found this as a warning when running tests, var defined but never used.

It was removed from usage in this patch: https://github.com/mozilla/donate.mozilla.org/commit/2713fa3c062dd57058ecf4354a408a8580158408

Pretty simple. No rush.