### PR TITLE
RTL support

### DIFF
--- a/less/components/amount-buttons.less
+++ b/less/components/amount-buttons.less
@@ -74,6 +74,12 @@
   }
 
   input#amount-other + label {
-    text-align: left;
+    text-align: initial;
+  }
+}
+
+html[dir="rtl"] .amount-buttons .amount-other-container {
+  .currency-symbol-container {
+    float: left;
   }
 }

--- a/less/components/checkbox.less
+++ b/less/components/checkbox.less
@@ -5,7 +5,14 @@
     margin-left: 10px;
     display: inline;
   }
-  text-align: left;
+  text-align: initial;
+}
+
+html[dir="rtl"] .checkbox {
+  input[type="checkbox"] + label {
+    margin-left: 0;
+    margin-right: 10px;
+  }
 }
 
 .signup-checkbox {

--- a/less/components/currency-dropdown.less
+++ b/less/components/currency-dropdown.less
@@ -11,3 +11,8 @@
     padding: 0;
   }
 }
+
+html[dir="rtl"] .currency-dropdown {
+  margin-left: 0;
+  margin-right: 5px;
+}

--- a/less/components/disclaimers.less
+++ b/less/components/disclaimers.less
@@ -6,7 +6,7 @@
   background-color: #CECCCA;
   border-radius: 6px;
   .other-ways-to-give {
-    text-align: left;
+    text-align: initial;
     margin: 16px auto;
   }
   .stripe-notice,

--- a/less/components/footer.less
+++ b/less/components/footer.less
@@ -19,6 +19,7 @@ footer {
   }
   ul {
     padding-left: 0;
+    padding-right: 0;
     list-style: none;
   }
 
@@ -27,6 +28,9 @@ footer {
       margin: 0 auto;
       width: 100%;
       max-width: 100%;
+      .half {
+        padding-right: 0;
+      }
     }
 
     .full,
@@ -35,6 +39,19 @@ footer {
     .two-third,
     .quarter {
       width: 100%;
+    }
+  }
+}
+
+html[dir="rtl"] footer .footer {
+  .half {
+    padding-right: 0;
+    padding-left: 35px;
+  }
+  @media screen and (max-width: 480px) {
+    .half {
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }

--- a/less/components/payment-buttons.less
+++ b/less/components/payment-buttons.less
@@ -136,3 +136,13 @@ label.payment-cc-label {
     }
   }
 }
+
+html[dir="rtl"] {
+  .paypal-button,
+  .cc-button {
+    .submitting-container .fa-cog {
+      margin-right: 0;
+      margin-left: 6px;
+    }
+  }
+}

--- a/less/pages/additional-info.less
+++ b/less/pages/additional-info.less
@@ -12,7 +12,7 @@
     .container {
       display: inline-block;
       vertical-align: top;
-      text-align: left;
+      text-align: initial;
       padding: 30px;
     }
     .heart-image {
@@ -55,17 +55,18 @@
     padding: 0 20px;
   }
   .disclaimers {
-    text-align: left;
+    text-align: initial;
     max-width: 420px;
     .other-ways-to-give,
     .need-help,
     .donation-notice,
     .stripe-notice {
       width: 100%;
-      text-align: left;
+      text-align: initial;
       margin-left: auto;
     }
   }
+
   @media screen and (min-width: 840px) {
     .additional-info-page {
       margin-top: 60px;
@@ -90,7 +91,20 @@
       .stripe-notice {
         max-width: 840px;
         margin-left: 0;
+        margin-right: 0;
       }
+    }
+  }
+}
+
+html[dir="rtl"] {
+  .additional-info-container {
+    .footer .half {
+      padding-left: 35px;
+      padding-right: 0;
+    }
+    .mozilla-watermark {
+      margin: 0 0 -2px 8px;
     }
   }
 }

--- a/less/pages/faq.less
+++ b/less/pages/faq.less
@@ -14,7 +14,7 @@
   }
   &.ways-to-give-page {
     .container h2 {
-      text-align: left;
+      text-align: initial;
     }
   }
   footer {

--- a/less/pages/thank-you.less
+++ b/less/pages/thank-you.less
@@ -120,6 +120,24 @@
     max-width: none;
   }
 }
+
+html[dir="rtl"] {
+  .thank-you-page,
+  .share-page {
+    #facebook {
+      margin-left: 8px;
+      margin-right: 5px;
+    }
+    #twitter {
+      margin-left: 5px;
+      margin-right: 8px;
+    }
+    #email {
+      float: left;
+    }
+  }
+}
+
 .new-header-test {
   .baseline-header {
     display: none;
@@ -220,6 +238,21 @@
         #twitter {
           margin-right: 7px;
         }
+      }
+    }
+  }
+}
+
+html[dir="rtl"] {
+  .social-test-with-email {
+    .share-page .social-with-email {
+      #facebook {
+        margin-left: 9px;
+        margin-right: 0;
+      }
+      #twitter {
+        margin-left: 9px;
+        margin-right: 0;
       }
     }
   }

--- a/less/shared.less
+++ b/less/shared.less
@@ -164,6 +164,17 @@ input[type="submit"] {
   float: left;
   padding-left: 5px;
   padding-right: 5px;
+  word-wrap: break-word;
+}
+
+html[dir="rtl"] {
+  .full,
+  .half,
+  .third,
+  .two-third,
+  .quarter {
+    float: right;
+  }
 }
 
 .full {
@@ -238,6 +249,15 @@ input[type="submit"] {
   float: right;
 }
 
+html[dir="rtl"] {
+  .left {
+    float: right;
+  }
+  .right {
+    float: left;
+  }
+}
+
 /* = Form Fields ========== */
 
 label {
@@ -246,6 +266,10 @@ label {
 
 input[type="radio"] + label {
   margin-left: 10px;
+}
+html[dir="rtl"] input[type="radio"] + label {
+  margin-left: 0;
+  margin-right: 10px;
 }
 
 input[type="text"],
@@ -263,10 +287,7 @@ input[type="email"] {
 
 input[type="email"] {
   padding-right: 33px;
-}
-input[name="lastname"],
-input[name="zip"] {
-  padding-left: 14px;
+  margin-top: 3px;
 }
 
 input[type="text"]:focus,
@@ -295,6 +316,13 @@ input.payment-type + label {
   cursor: pointer;
   white-space: nowrap;
   line-height: 1.42857;
+}
+
+html[dir="rtl"] {
+  input[name="donation_amount"] + label,
+  input.payment-type + label {
+    margin-right: 0;
+  }
 }
 
 input[name="donation_amount"]:checked + label,
@@ -403,6 +431,29 @@ input.payment-type + label {
   }
 }
 
+html[dir="rtl"] {
+  .paypal-disabled {
+    #secure-label {
+      left: 5px;
+      right: auto;
+    }
+    .credit-card-logos {
+      float: right;
+      margin-left: 0;
+      margin-right: -20px;
+      &.no-amex {
+        margin-left: 0;
+        margin-right: -10px;
+      }
+
+      @media screen and (max-width: 480px) {
+        margin-left: 0;
+        margin-right: -16px;
+      }
+    }
+  }
+}
+
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
   -moz-appearance: none;
@@ -446,6 +497,10 @@ i.fa.field-icon {
     font-size: 15px;
   }
 }
+html[dir="rtl"] i.fa.field-icon {
+  left: auto;
+  right: 12px;
+}
 
 i.fa.hint {
   position: absolute;
@@ -455,6 +510,11 @@ i.fa.hint {
   right: 10px;
   cursor: pointer;
 }
+html[dir="rtl"] i.fa.hint {
+  left: auto;
+  right: 10px;
+}
+
 
 /* = Layout, sections, and other UI related stuff ========== */
 
@@ -484,6 +544,10 @@ i.fa.hint {
     margin-right: 6px;
   }
 }
+html[dir="rtl"] #secure-label i.fa {
+  margin-left: 6px;
+  margin-right: 0;
+}
 
 /* Parsley.js / Validation Styling */
 .parsley-errors-list,
@@ -496,6 +560,7 @@ i.fa.hint {
   display: block;
   list-style: none;
   padding-left: 0;
+  padding-right: 0;
   margin: 0;
 }
 

--- a/less/shared.less
+++ b/less/shared.less
@@ -283,11 +283,11 @@ input[type="email"] {
   border-radius: 3px;
   padding: 6px 7px 6px 33px;
   background-color: #F7F9FA;
+  outline: none;
 }
 
 input[type="email"] {
   padding-right: 33px;
-  margin-top: 3px;
 }
 
 input[type="text"]:focus,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,8 +39,12 @@ var Index = React.createClass({
     if (this.props.locale) {
       polyfillLocale = '&locale=' + this.props.locale;
     }
+    var dir = 'ltr';
+    if (['ar', 'fa', 'he', 'ur'].indexOf(this.props.locale) >= 0) {
+      dir = 'rtl';
+    }
     return (
-      <html>
+      <html dir={dir}>
         <head>
           <meta charSet="UTF-8"/>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>


### PR DESCRIPTION
WIP, but even if it gets a r+ soon, let’s hold until January anyway as it’s too risky.

Tried to test "tests" as much as possible (like the thank-you alternative design), and also only tested in Firefox Nightly. Pretty sure I’ll find nonsense in Safari…

On the approach itself, I tried to keep the RTL blocks close to the rules it’s overwriting, so that it’s easier to understand while reading the stylesheet. I’ve considered using LESS variables and things like https://github.com/DevelopmentIL/direction.less but in the end I think html[dir="rtl"] is the easiest to understand and maintain. FWIW, this is also what’s used on mozilla.org https://github.com/mozilla/bedrock/blob/master/media/css/firefox/desktop/common.less#L63
But would love to hear your thoughts on that, though.

Currently, the only RTL locale we support is Hebrew (he), but with this patch we can try to get Arabic, at least, and motivate Hebrew localizers to complete the translation.