### PR TITLE
Expose the email subscription form to all relevant locales

### DIFF
--- a/src/pages/thank-you.js
+++ b/src/pages/thank-you.js
@@ -17,7 +17,7 @@ var ThankYou = React.createClass({
   render: function() {
     var className = "row thank-you-page";
     var signUpOrSocial = (<Social/>);
-    if (/^(en|de)(\b|$)/.test(this.context.intl.locale)) {
+    if (/^(en|de|es|fr|pl|pt-BR)(\b|$)/.test(this.context.intl.locale)) {
       signUpOrSocial = (<Signup country={this.props.country} email={this.props.email}/>);
     }
     if (this.props.test) {


### PR DESCRIPTION
As discussed with @WillatMozFdn, let’s expose the subscription form to more locales than en-* and de.
We’re not including Italian because the MoCo list does not support it. I assume this is the only place that needs to be updated. I can’t test locally if I actually get subscribed, but this at least displays the form correctly.