### PR TITLE
Fix text-transform in Turkish (Bug 231162)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,7 +44,7 @@ var Index = React.createClass({
       dir = 'rtl';
     }
     return (
-      <html dir={dir}>
+      <html dir={dir} lang={this.props.locale}>
         <head>
           <meta charSet="UTF-8"/>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>


### PR DESCRIPTION
More background if you’re not familiar with the changes the browser is making depending on the value of the lang attribute (I was not): https://bugzilla.mozilla.org/show_bug.cgi?id=231162

Basically, before:
<img width="102" alt="capture d ecran 2017-08-01 a 13 01 04" src="https://user-images.githubusercontent.com/1294206/28824597-9debb7e0-76ba-11e7-9d75-f79de059c22d.png">

After the fix, using a Turkish browser (note the last character):
<img width="109" alt="capture d ecran 2017-08-01 a 13 00 58" src="https://user-images.githubusercontent.com/1294206/28824599-a22fbd42-76ba-11e7-95af-eedb171ec141.png">



