### PR TITLE
Fix #1569 - Cancel Thunderbird donation in paypal sends user back to …

### DIFF
--- a/routes/paypal.js
+++ b/routes/paypal.js
@@ -18,6 +18,10 @@ function setupPaypal(transaction, callback) {
 
   var returnUrl = transaction.serverUri + '/api/paypal-redirect/' + frequency + '/' + locale + '/' + appName + '/' + accountType + '/';
 
+  var cancelUrl = transaction.serverUri + '/';
+  if (appName === 'thunderbird') {
+    cancelUrl += 'thunderbird/';
+  }
   var charge = {
     USER: paypalCreds.PAYPAL_USER,
     PWD: paypalCreds.PAYPAL_PWD,
@@ -31,7 +35,7 @@ function setupPaypal(transaction, callback) {
     LOCALECODE: paypalLocales[locale],
     NOSHIPPING: '1',
     ALLOWNOTE: '0',
-    cancelUrl: transaction.serverUri + '/',
+    cancelUrl: cancelUrl,
     returnUrl: returnUrl
   };
 


### PR DESCRIPTION
…Mozilla donation page instead of Thunderbird donation page.

I think this should fix it, but it seems testing checkout on localhost doesn't work  so I can't really verify it. Maybe there's some env variable that I would have to set?