### PR TITLE
Adding signatures to stripe webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux": "3.6.0",
     "request": "2.67.0",
     "scooter": "2.0.1",
-    "stripe": "4.1.0",
+    "stripe": "4.19.0",
     "style-loader": "0.13.0",
     "throng": "1.0.1",
     "webpack": "1.12.9",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux": "3.6.0",
     "request": "2.67.0",
     "scooter": "2.0.1",
-    "stripe": "4.19.0",
+    "stripe": "5.1.1",
     "style-loader": "0.13.0",
     "throng": "1.0.1",
     "webpack": "1.12.9",

--- a/routes/index.js
+++ b/routes/index.js
@@ -463,7 +463,15 @@ var routes = {
     }
   },
   'stripe-charge-failed': function(request, reply) {
-    var event = request.payload;
+    var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_FAILED;
+    var signature = request.headers["stripe-signature"];
+
+    var event;
+    try {
+      event = stripe.constructEvent(request.payload, signature, endpointSecret);
+    } catch (constructEventErr) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    }
 
     if (event.type !== 'charge.failed') {
       return reply('This hook only processes charge failed events');
@@ -480,7 +488,15 @@ var routes = {
     return reply("charge failed event processed");
   },
   'stripe-charge-refunded': function(request, reply) {
-    var event = request.payload;
+    var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_REFUNDED;
+    var signature = request.headers["stripe-signature"];
+
+    var event;
+    try {
+      event = stripe.constructEvent(request.payload, signature, endpointSecret);
+    } catch (constructEventErr) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    }
 
     if (event.type !== 'charge.refunded') {
       return reply('This hook only processes charge.refunded events');

--- a/routes/index.js
+++ b/routes/index.js
@@ -590,11 +590,10 @@ var routes = {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_SUCCESS;
     var signature = request.headers["stripe-signature"];
 
-    var event;
-    try {
-      event = stripe.constructEvent(request.payload, signature, endpointSecret);
-    } catch (constructEventErr) {
-      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    var event = stripe.constructEvent(request.payload, signature, endpointSecret);
+
+    if (event[0] === null) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', event[1]));
     }
 
     var charge = event.data.object;

--- a/routes/index.js
+++ b/routes/index.js
@@ -511,7 +511,14 @@ var routes = {
   'stripe-dispute': function(request, reply) {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_DISPUTE;
     var signature = request.headers["stripe-signature"];
-    var event = stripe.webhooks.constructEvent(request.payload, signature, endpointSecret);
+
+    var event;
+    try {
+      event = stripe.constructEvent(request.payload, signature, endpointSecret);
+    } catch (constructEventErr) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    }
+
 
     var disputeEvents = [
       'charge.dispute.closed',
@@ -566,7 +573,13 @@ var routes = {
   'stripe-charge-succeeded': function(request, reply) {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_SUCCESS;
     var signature = request.headers["stripe-signature"];
-    var event = stripe.webhooks.constructEvent(request.payload, signature, endpointSecret);
+
+    var event;
+    try {
+      event = stripe.constructEvent(request.payload, signature, endpointSecret);
+    } catch (constructEventErr) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    }
 
     var charge = event.data.object;
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -369,7 +369,7 @@ var routes = {
 
           request.log(['paypal', 'checkout', frequency], log_details);
 
-          var timestamp = new Date(data.txn.PAYMENTINFO_0_ORDERTIME).getTime() / 1000
+          var timestamp = new Date(data.txn.PAYMENTINFO_0_ORDERTIME).getTime() / 1000;
 
           basket.queue({
             event_type: "donation",
@@ -435,7 +435,7 @@ var routes = {
 
           request.log(['paypal', 'checkout', frequency], log_details);
 
-          var timestamp = new Date(data.txn.TIMESTAMP).getTime() / 1000
+          var timestamp = new Date(data.txn.TIMESTAMP).getTime() / 1000;
 
           // Create unique tx id by combining PayerID and timestamp
           var stamp = Date.now() / 100;
@@ -509,7 +509,9 @@ var routes = {
     return reply("charge event processed");
   },
   'stripe-dispute': function(request, reply) {
-    var event = request.payload;
+    var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_DISPUTE;
+    var signature = request.headers["stripe-signature"];
+    var event = stripe.webhooks.constructEvent(request.payload, signature, endpointSecret);
 
     var disputeEvents = [
       'charge.dispute.closed',
@@ -562,7 +564,10 @@ var routes = {
 
   },
   'stripe-charge-succeeded': function(request, reply) {
-    var event = request.payload;
+    var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_SUCCESS;
+    var signature = request.headers["stripe-signature"];
+    var event = stripe.webhooks.constructEvent(request.payload, signature, endpointSecret);
+
     var charge = event.data.object;
 
     if (event.type !== 'charge.succeeded') {

--- a/routes/index.js
+++ b/routes/index.js
@@ -466,11 +466,10 @@ var routes = {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_FAILED;
     var signature = request.headers["stripe-signature"];
 
-    var event;
-    try {
-      event = stripe.constructEvent(request.payload, signature, endpointSecret);
-    } catch (constructEventErr) {
-      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    var event = stripe.constructEvent(request.payload, signature, endpointSecret);
+
+    if (!event) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret'));
     }
 
     if (event.type !== 'charge.failed') {
@@ -491,11 +490,10 @@ var routes = {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_REFUNDED;
     var signature = request.headers["stripe-signature"];
 
-    var event;
-    try {
-      event = stripe.constructEvent(request.payload, signature, endpointSecret);
-    } catch (constructEventErr) {
-      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    var event = stripe.constructEvent(request.payload, signature, endpointSecret);
+
+    if (!event) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret'));
     }
 
     if (event.type !== 'charge.refunded') {
@@ -528,11 +526,10 @@ var routes = {
     var endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_DISPUTE;
     var signature = request.headers["stripe-signature"];
 
-    var event;
-    try {
-      event = stripe.constructEvent(request.payload, signature, endpointSecret);
-    } catch (constructEventErr) {
-      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', constructEventErr));
+    var event = stripe.constructEvent(request.payload, signature, endpointSecret);
+
+    if (!event) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret'));
     }
 
 
@@ -592,8 +589,8 @@ var routes = {
 
     var event = stripe.constructEvent(request.payload, signature, endpointSecret);
 
-    if (event[0] === null) {
-      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret', event[1]));
+    if (!event) {
+      return reply(boom.forbidden('An error occurred while verifying the webhook signing secret'));
     }
 
     var charge = event.data.object;

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -89,6 +89,9 @@ var stripeRoutes = {
   },
   retrieveSubscription: function(customerId, subscriptionId, options, callback) {
     stripe.customers.retrieveSubscription(customerId, subscriptionId, options, callback);
+  },
+  constructEvent: function(payload, signature, endpointSecret) {
+    return stripe.webhooks.constructEvent(payload, signature, endpointSecret);
   }
 };
 

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -91,7 +91,15 @@ var stripeRoutes = {
     stripe.customers.retrieveSubscription(customerId, subscriptionId, options, callback);
   },
   constructEvent: function(payload, signature, endpointSecret) {
-    return stripe.webhooks.constructEvent(payload, signature, endpointSecret);
+    var event;
+
+    try {
+      event = stripe.webhooks.constructEvent(payload, signature, endpointSecret);
+    } catch (constructEventErr) {
+      event = [null, constructEventErr];
+    }
+
+    return event;
   }
 };
 

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -96,7 +96,7 @@ var stripeRoutes = {
     try {
       event = stripe.webhooks.constructEvent(payload, signature, endpointSecret);
     } catch (constructEventErr) {
-      event = [null, constructEventErr];
+      console.error('Error: ', constructEventErr);
     }
 
     return event;

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -96,7 +96,7 @@ var stripeRoutes = {
     try {
       event = stripe.webhooks.constructEvent(payload, signature, endpointSecret);
     } catch (constructEventErr) {
-      console.error('Error: ', constructEventErr);
+      console.error('constructEvent error: ', constructEventErr);
     }
 
     return event;

--- a/server.js
+++ b/server.js
@@ -308,14 +308,22 @@ module.exports = function(options) {
       method: "POST",
       path: "/stripe/charge-failed",
       config: {
-        auth: "stripe"
+        auth: "stripe",
+        payload: {
+          output: 'data',
+          parse: false
+        }
       },
       handler: routes['stripe-charge-failed']
     }, {
       method: "POST",
       path: "/stripe/charge-refunded",
       config: {
-        auth: "stripe"
+        auth: "stripe",
+        payload: {
+          output: 'data',
+          parse: false
+        }
       },
       handler: routes['stripe-charge-refunded']
     }

--- a/server.js
+++ b/server.js
@@ -286,14 +286,22 @@ module.exports = function(options) {
       method: "POST",
       path: "/stripe/dispute-callback",
       config: {
-        auth: "stripe"
+        auth: "stripe",
+        payload: {
+          output: 'data',
+          parse: false
+        }
       },
       handler: routes['stripe-dispute']
     }, {
       method: "POST",
       path: "/stripe/charge-succeeded",
       config: {
-        auth: "stripe"
+        auth: "stripe",
+        payload: {
+          output: 'data',
+          parse: false
+        }
       },
       handler: routes['stripe-charge-succeeded']
     }, {


### PR DESCRIPTION
Fixes #1766 

I also added two missing semicolons to make the linter happy.


Todos:
- [x] Move signature code to stripe.js
- [x] Bump stripe module version to v5: I need to upgrade to at least 4.19 to use the webhooks signature feature but let's try moving to v5 and see if break stuff or not.
- [x] Tests

Deploy todos:
- [x] Clean up the test webhooks I've setup
- [x] Setup signature validation for `stripe-charge-failed` and `stripe-charge-refunded`
- [x] Add the new env variables for both staging and deploy stacks (`STRIPE_WEBHOOK_SIGNATURE_CHARGE_SUCCESS` and `STRIPE_WEBHOOK_SIGNATURE_CHARGE_FAILED`, `STRIPE_WEBHOOK_SIGNATURE_CHARGE_REFUNDED`, `STRIPE_WEBHOOK_SIGNATURE_DISPUTE`). ⚠️ Each webhook has its own signature key ⚠️