### PR TITLE
Extra margin on Submit button to fix outline clipping bug.

### DIFF
--- a/less/components/submit-button.less
+++ b/less/components/submit-button.less
@@ -3,8 +3,6 @@
     margin-top: 25px;
   }
   .submit-btn {
-    margin-top: 5px;
-    margin-bottom: 0;
     width: 100%;
     border-radius: 3px;
     display: inline-block;
@@ -16,8 +14,7 @@
     padding: 3px 5px 7px;
     -moz-user-select: none;
     color: #fff;
-    margin-top: 5px;
-    margin-bottom: 0;
+    margin: 5px 0;
     &:hover {
       background-color: #ff7b87;
     }


### PR DESCRIPTION
This extra bottom margin allow the full outline of the Submit button to be visible when it is pressed down. It was previously being clipped because the `form` element that contains the button has an `overflow: hidden;` property.

To test, go to the `/sepa` form and click the Submit button, it should now appear like this...

![image](https://user-images.githubusercontent.com/25212/32851859-115c937e-c9eb-11e7-82ba-93c79d16b814.png)

Fixes #1875