### PR TITLE
Reverting SEPA string changes

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -30,9 +30,9 @@ credit_card=Credit / debit card
 submitting=Submitting…
 
 # privacy policy variants
-privacy_policy_var_a_v2=We care about privacy and about helping you make informed choices. We want you to understand that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards and SEPA Direct Debit) or <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
-privacy_policy_var_b_v2=Your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards and SEPA Direct Debit) or <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
-privacy_policy_var_c_v2=By making a donation, you acknowledge that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards and SEPA Direct Debit) or by <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a> in accordance with their privacy policies, and a record of your donation will be stored by <a href="https://www.mozilla.org/privacy/">Mozilla</a>.
+privacy_policy_var_a=We care about privacy and about helping you make informed choices. We want you to understand that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
+privacy_policy_var_b=Your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">Paypal</a>, and a record of your donation will be stored by Mozilla.
+privacy_policy_var_c=By making a donation, you acknowledge that your payment details will be processed by <a href="https://stripe.com/privacy/">Stripe</a> (for credit/debit cards) or by <a href="https://www.paypal.com/webapps/mpp/ua/privacy-full">Paypal</a> in accordance with their privacy policies, and a record of your donation will be stored by <a href="https://www.mozilla.org/privacy/">Mozilla</a>.
 
 # Obsolete string, do not remove
 other_way_to_give=Other ways to give: {bitcoinLink} | {checkLink}

--- a/src/components/single-form.js
+++ b/src/components/single-form.js
@@ -39,7 +39,7 @@ var singleForm = React.createClass({
   },
   renderPrivacyPolicy: function() {
     return (
-      <p className="full"><FormattedHTMLMessage id="privacy_policy_var_b_v2"/></p>
+      <p className="full"><FormattedHTMLMessage id="privacy_policy_var_b"/></p>
     );
   },
   validateStripe: function() {


### PR DESCRIPTION
This undoes the string changes we made for SEPA. This relates to the copy underneath the payment options, which should now appear as...

![image](https://user-images.githubusercontent.com/25212/32914719-665dc1d2-cacb-11e7-9120-913f2cec1dad.png)
