### PR TITLE
Updated left-padding for email field

### DIFF
--- a/less/pages/thank-you.less
+++ b/less/pages/thank-you.less
@@ -18,6 +18,11 @@
 .thank-you-page,
 .share-page {
   display: inline;
+
+  input[type=email] {
+    padding-left: 30px;
+  }
+
   .header {
     text-align: center;
     margin-top: 0;


### PR DESCRIPTION
On the `thank-you` page, the email field has the correct left padding now, which leaves room for the envelope icon, like this...

<img src="https://user-images.githubusercontent.com/25212/32864348-ba4994aa-ca13-11e7-865d-b15c142d794c.png" width="300" />


Fixes #1899