### PR TITLE
Updated overflow property for modal.

### DIFF
--- a/less/components/monthly-upgrade.less
+++ b/less/components/monthly-upgrade.less
@@ -1,12 +1,11 @@
 .upgrade-container {
   .modal-container {
     background: #D8D5CC;
-    overflow: hidden;
+    overflow: auto;
   }
   .upgrade-modal {
     background: #FFFFFF;
     padding: 30px;
-    overflow: hidden;
     border-radius: 6px;
     color: #333;
     text-align: center;


### PR DESCRIPTION
This way, if the window is too small, the modal will scroll. Mistakenly used `hidden` before. 

cc @ScottDowne 

On a small window, should appear as...

![image](https://user-images.githubusercontent.com/25212/33224528-2c92edc4-d11f-11e7-9ea2-f31c43431fb2.png)
