### PR TITLE
Initial removal of redux persist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "react-redux": "4.4.5",
     "react-router": "2.0.0",
     "redux": "3.6.0",
-    "redux-persist": "^4.10.1",
     "request": "2.67.0",
     "scooter": "2.0.1",
     "stripe": "5.1.1",

--- a/src/components/amount-buttons.js
+++ b/src/components/amount-buttons.js
@@ -29,7 +29,12 @@ var AmountButton = React.createClass({
     }
     return (
       <div className="third">
-        <input onChange={this.props.onChange} onClick={this.onClickEvent} checked={checked} className="amount-radio" type="radio" name="donation_amount" value={this.props.value} id={"amount-" + this.props.value}/>
+        <input onChange={this.props.onChange}
+          onClick={this.onClickEvent} checked={checked}
+          className="amount-radio" type="radio"
+          name="donation_amount" value={this.props.value}
+          id={"amount-" + this.props.value} autoComplete="off"
+        />
         <label htmlFor={"amount-" + this.props.value} className="amount-button large-label-size">
           { this.props.currencyCode && this.props.value ?
             <FormattedNumber
@@ -81,6 +86,7 @@ var AmountOtherButton = React.createClass({
             onClick={this.onRadioClick}
             onChange={this.onRadioChange}
             value={this.props.amount}
+            autoComplete="off"
           />
           <label htmlFor="amount-other" className="large-label-size">
             <span className="currency-symbol-container">

--- a/src/components/amount-input.js
+++ b/src/components/amount-input.js
@@ -68,6 +68,7 @@ var AmountInput = React.createClass({
     var type = this.props.type || "";
     return (
       <input id={id}
+        autoComplete="off"
         className={className}
         type={type}
         value={inputValue}

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -23,7 +23,11 @@ var Checkbox = React.createClass({
       <div className="full checkbox">
         <div className="row">
           <div className="full">
-            <input type="checkbox" onChange={this.onChange} checked={this.props.checked} name={this.props.name} id={this.props.id}/>
+            <input type="checkbox"
+              onChange={this.onChange} autoComplete="off"
+              checked={this.props.checked}
+              name={this.props.name} id={this.props.id}
+            />
             <label htmlFor={this.props.id}>
               <FormattedHTMLMessage id={ this.props.intlId } />
             </label>

--- a/src/components/create-element.js
+++ b/src/components/create-element.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-import { persistStore, autoRehydrate } from 'redux-persist';
-import { asyncSessionStorage } from 'redux-persist/storages';
 
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
@@ -20,9 +18,6 @@ var createElement = React.createClass({
         presets: this.props.presets,
         amount: this.props.amount
       }
-    }, autoRehydrate());
-    persistStore(store, {
-      storage: asyncSessionStorage
     });
     return (
       <Provider store={store}>

--- a/src/components/currency-dropdown.js
+++ b/src/components/currency-dropdown.js
@@ -18,7 +18,7 @@ var CurrencyDropdown = React.createClass({
   },
   render: function() {
     return (
-      <select onChange={this.onChange} autocomplete="off" className="currency-dropdown" value={this.props.currency.code}>
+      <select onChange={this.onChange} autoComplete="off" className="currency-dropdown" value={this.props.currency.code}>
         {Object.keys(currencyData).map(function(currency, i) {
           return (
             <option value={currency} key={i}>

--- a/src/components/currency-dropdown.js
+++ b/src/components/currency-dropdown.js
@@ -18,7 +18,7 @@ var CurrencyDropdown = React.createClass({
   },
   render: function() {
     return (
-      <select onChange={this.onChange} className="currency-dropdown" value={this.props.currency.code}>
+      <select onChange={this.onChange} autocomplete="off" className="currency-dropdown" value={this.props.currency.code}>
         {Object.keys(currencyData).map(function(currency, i) {
           return (
             <option value={currency} key={i}>

--- a/src/components/donation-frequency.js
+++ b/src/components/donation-frequency.js
@@ -27,13 +27,13 @@ var DonationFrequency = React.createClass({
       <div>
         <div className="row donation-frequency">
           <div className="frequency-radio">
-            <input name={inputName} checked={frequency !== "monthly"} className="one-time-payment"
+            <input name={inputName} autoComplete="off" checked={frequency !== "monthly"} className="one-time-payment"
               onChange={this.onChange} type="radio" value="single" id={onTimeId}
             />
             <label htmlFor={onTimeId} className="medium-label-size">{this.context.intl.formatMessage({id: 'one_time'})}</label>
           </div>
           <div className="frequency-radio">
-            <input name={inputName} checked={frequency === "monthly"} className="monthly-payment"
+            <input name={inputName} autoComplete="off" checked={frequency === "monthly"} className="monthly-payment"
               onChange={this.onChange} type="radio" value="monthly" id={monthlyId}
             />
             <label htmlFor={monthlyId} className="medium-label-size">{this.context.intl.formatMessage({id: 'monthly'})}</label>

--- a/src/components/email-input.js
+++ b/src/components/email-input.js
@@ -21,7 +21,12 @@ var EmailInput = React.createClass({
           <div className="full">
             <div className="field-container">
               <i className="fa fa-envelope field-icon"></i>
-              <input type="email" ref={(input) => { this.inputElement = input; }} className={inputClassName} name="email" value={this.props.email} onChange={this.onEmailChange} placeholder={this.context.intl.formatMessage({id: 'email'})}/>
+              <input type="email" autoComplete="off"
+                ref={(input) => { this.inputElement = input; }}
+                className={inputClassName} name="email"
+                value={this.props.email} onChange={this.onEmailChange}
+                placeholder={this.context.intl.formatMessage({id: 'email'})}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What redux persist was fixing

autocomplete is an attribute on input elements that does this "The browser is allowed to automatically complete the value based on values that the user has entered during previous uses" see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete

This autocompleted value is what the user sees, but never gets put into the app state, and thus app state gets out of sync with what the user sees.

This could give users the possibility, if they refresh the page after interacting with it, to donate an amount they didn't expect to, or monthly/one time when they meant to give the other way. So it's pretty important.

## Why we chose redux persist

Redux persist was a quick solution that fixed the problem in one place for all inputs. It did this by putting the state of the app in SessionStorage, which matches what the user sees.

This caused query params values to only work on a new tab, which wasn't great.

## This patch's solution without Redux Persist

We should instead just turn off autocomplete on all inputs.