### PR TITLE
Fix plans script & automate plan sync

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node start.js
+release: node ops/stripe_plans.js

--- a/ops/stripe_plans.js
+++ b/ops/stripe_plans.js
@@ -3,9 +3,10 @@
 require("habitat").load();
 
 var async = require("async");
+var path = require("path");
 var Stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
-var currencies = Object.keys(require("../data/currencies"));
+var currencies = Object.keys(require(path.resolve( __dirname, "../src/data/currencies")));
 var local_plans = {};
 currencies.forEach((currency) => {
   local_plans[currency] = {


### PR DESCRIPTION
This patch updates the `stripe_plans.js` script (path changed), and will execute the script as a release command, so that staging (test mode on Stripe) and production (live mode on Stripe) will always keep their plans in sync.

Fixes #1938 