### PR TITLE
Fix the disputed charge webhook

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -721,7 +721,7 @@ const routes = {
 
     const event_type = event.type;
 
-    if (event_type === 'charge.dispute.created' && status === 'lost') {
+    if (event_type === 'charge.dispute.created' && status !== 'lost') {
       try {
         await stripe.closeDispute(dispute_id);
         // statements


### PR DESCRIPTION
Reverse the incorrect logic that was supposed to determine if a dispute should be closed.