### PR TITLE
Capture the landing URL so we can forward it to the CRM

### DIFF
--- a/server/base-routes.js
+++ b/server/base-routes.js
@@ -78,7 +78,8 @@ const baseRoutes = [
           address: Joi.string().allow(''),
           city: Joi.string().allow(''),
           code: Joi.string().allow(''),
-          description: Joi.string().required()
+          description: Joi.string().required(),
+          donation_url: Joi.string().required()
         }
       },
       response: {
@@ -137,7 +138,8 @@ const baseRoutes = [
           amount: Joi.number().required(),
           locale: Joi.string().min(2).max(12).required(),
           currency: Joi.any().valid(currencyFor.paypal).required(),
-          appName: Joi.string()
+          appName: Joi.string(),
+          donation_url: Joi.string().required()
         }
       },
       response: {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -80,7 +80,8 @@ const routes = {
       stripeToken,
       frequency,
       signup,
-      country
+      country,
+      donation_url
     } = transaction;
     const amount = amountModifier.stripe(transaction.amount, currency);
     const metadata = { email, locale };
@@ -195,7 +196,8 @@ const routes = {
         recurring: false,
         service: "stripe",
         transaction_id: charge.id,
-        project: metadata.thunderbird ? "thunderbird" : ( metadata.glassroomnyc ? "glassroomnyc" : "mozillafoundation" )
+        project: metadata.thunderbird ? "thunderbird" : ( metadata.glassroomnyc ? "glassroomnyc" : "mozillafoundation" ),
+        donation_url
       });
 
       const cookie = {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -421,7 +421,7 @@ const routes = {
     let frequency = transaction.frequency || "";
     let currency = transaction.currency;
     let amount = amountModifier.paypal(transaction.amount, currency);
-    let {donation_url} = transaction;
+    let { donation_url } = transaction;
 
     let details = {
       amount: amount,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -459,7 +459,7 @@ const routes = {
       paypal_request_sale_service
     });
 
-    const cookie = { donation_url};
+    const cookie = { donation_url };
     const response = {
       endpoint: process.env.PAYPAL_ENDPOINT,
       token: checkoutDetails.TOKEN
@@ -493,8 +493,8 @@ const routes = {
     // in case someone's browser isn't sending cookies
     const encryptedCookie = request.state && request.state.session;
     if (encryptedCookie) {
-       try {
-        cookie = await decrypt(encryptedCookie);
+      try {
+        let cookie = await decrypt(encryptedCookie);
         donation_url = cookie && cookie.donation_url;
       } catch (err) {
         // lets not throw away money because we don't have a URL
@@ -600,7 +600,7 @@ const routes = {
       });
 
       return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`)
-      .unstate("session");
+        .unstate("session");
     }
 
     let paypal_checkout_details_service;
@@ -694,7 +694,7 @@ const routes = {
     });
 
     return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`)
-    .unstate("session");
+      .unstate("session");
   },
   'stripe-charge-refunded': function(request, h) {
     let endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_REFUNDED;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -421,6 +421,7 @@ const routes = {
     let frequency = transaction.frequency || "";
     let currency = transaction.currency;
     let amount = amountModifier.paypal(transaction.amount, currency);
+    let {donation_url} = transaction;
 
     let details = {
       amount: amount,
@@ -458,16 +459,48 @@ const routes = {
       paypal_request_sale_service
     });
 
-    return h.response({
+    const cookie = { donation_url};
+    const response = {
       endpoint: process.env.PAYPAL_ENDPOINT,
       token: checkoutDetails.TOKEN
-    }).code(200);
+    };
+
+    try {
+      const encryptedCookie = await encrypt(cookie);
+      return h.response(response)
+        .state("session", encryptedCookie)
+        .code(200);
+
+    } catch (err) {
+      request.log(['error', 'paypal', 'cookie'], {
+        request_id,
+        code: err.code,
+        message: err.message
+      });
+
+      return h.response(response).code(200);
+    }
   },
   'paypal-redirect': async function(request, h) {
     let locale = request.params.locale || '';
     if (locale) {
       locale = '/' + locale;
     }
+
+    let donation_url;
+
+    // don't fail if the donation_url isn't available,
+    // in case someone's browser isn't sending cookies
+    const encryptedCookie = request.state && request.state.session;
+    if (encryptedCookie) {
+       try {
+        cookie = await decrypt(encryptedCookie);
+        donation_url = cookie && cookie.donation_url;
+      } catch (err) {
+        // lets not throw away money because we don't have a URL
+      }
+    }
+
     let appName = request.params.appName;
     let location = "thank-you";
     if (appName === "thunderbird") {
@@ -562,10 +595,12 @@ const routes = {
         recurring: false,
         service: 'paypal',
         transaction_id,
-        project: appName
+        project: appName,
+        donation_url
       });
 
-      return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`);
+      return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`)
+      .unstate("session");
     }
 
     let paypal_checkout_details_service;
@@ -654,10 +689,12 @@ const routes = {
       service: "paypal",
       transaction_id,
       subscription_id,
-      project: appName
+      project: appName,
+      donation_url
     });
 
-    return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`);
+    return h.redirect(`${locale}/${location}/?frequency=${frequency}&tx=${transaction_id}&amt=${donation_amount}&cc=${currency}&email=${email}`)
+    .unstate("session");
   },
   'stripe-charge-refunded': function(request, h) {
     let endpointSecret = process.env.STRIPE_WEBHOOK_SIGNATURE_CHARGE_REFUNDED;

--- a/src/mixins/paypal.js
+++ b/src/mixins/paypal.js
@@ -36,6 +36,7 @@ var PaypalMixin = {
     props.description = description;
     props.appName = appName || "mozillafoundation";
     props.locale = this.context.intl.locale;
+    props.donation_url = window.location.href;
     submit("/api/paypal", props, function(json) {
       window.location = json.endpoint + "/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=" + json.token;
     });

--- a/src/mixins/stripe.js
+++ b/src/mixins/stripe.js
@@ -125,7 +125,8 @@ var StripeMixin = {
           locale: locale,
           email: response.email,
           code: response.card.address_zip,
-          description: description
+          description: description,
+          donation_url: window.location.href
         };
 
         checkoutProps.country = response.card.address_country;


### PR DESCRIPTION
Stripe can do this without needing a Cookie, but Paypal uses a two stage process, so a Cookie is necessary.