### PR TITLE
Use "SWIFT/BIC Code" wording to make it clear they are the same.

### DIFF
--- a/locales/en-US/ways-to-give.properties
+++ b/locales/en-US/ways-to-give.properties
@@ -35,7 +35,7 @@ london=London, United Kingdom
 sort_code=Bank Sort Code:
 
 # Feel free to use "SWIFT/BIC Code", those are the same
-swift_code=SWIFT Code:
+swift_bic_code=SWIFT/BIC Code:
 beneficiary=Beneficiary Name (For credit to):
 IBAN=IBAN:
 account_number=Account Number (8 digits):

--- a/src/pages/thunderbird/faq.js
+++ b/src/pages/thunderbird/faq.js
@@ -126,7 +126,7 @@ var Faq = React.createClass({
                 {" "}
                 <FormattedHTMLMessage id='frankfurt' />
                 <br/>
-                <b><FormattedHTMLMessage id='swift_code' /></b>
+                <b><FormattedHTMLMessage id='swift_bic_code' /></b>
                 {" SCBLDEFX"}
                 <br/>
                 <b><FormattedHTMLMessage id='beneficiary' /></b>
@@ -165,7 +165,7 @@ var Faq = React.createClass({
                 {" Thunderbird"}
               </p>
               <p>
-                <b><FormattedHTMLMessage id='swift_code' /></b>
+                <b><FormattedHTMLMessage id='swift_bic_code' /></b>
                 {" NWBKGB2L"}
                 <br/>
                 <b><FormattedHTMLMessage id='IBAN' /></b>
@@ -214,7 +214,7 @@ var Faq = React.createClass({
               <b><FormattedHTMLMessage id='memo_field' /></b>
               {" Thunderbird"}
               <br/>
-              <b><FormattedHTMLMessage id='swift_code' /></b>
+              <b><FormattedHTMLMessage id='swift_bic_code' /></b>
               {" SVBKUS6S"}
               <br/><br/>
             </Panel>

--- a/src/pages/ways-to-give.js
+++ b/src/pages/ways-to-give.js
@@ -53,7 +53,7 @@ var WaysToGive = React.createClass({
             {" "}
             <FormattedHTMLMessage id='frankfurt' />
             <br/>
-            <b><FormattedHTMLMessage id='swift_code' /></b>
+            <b><FormattedHTMLMessage id='swift_bic_code' /></b>
             {" SCBLDEFX"}
             <br/>
             <b><FormattedHTMLMessage id='beneficiary' /></b>
@@ -86,7 +86,7 @@ var WaysToGive = React.createClass({
             {" SVB RE Mozilla Foundation"}
           </p>
           <p>
-            <b><FormattedHTMLMessage id='swift_code' /></b>
+            <b><FormattedHTMLMessage id='swift_bic_code' /></b>
             {" NWBKGB2L"}
             <br/>
             <b><FormattedHTMLMessage id='IBAN' /></b>
@@ -131,7 +131,7 @@ var WaysToGive = React.createClass({
             <b><FormattedHTMLMessage id='account_number_usa' /></b>
             {" 3302228513"}
             <br/>
-            <b><FormattedHTMLMessage id='swift_code' /></b>
+            <b><FormattedHTMLMessage id='swift_bic_code' /></b>
             {" SVBKUS6S"}
           </p>
           <br/>


### PR DESCRIPTION
Like the comment in the localization file says, SWIFT code and BIC code are the same. Make that clear in the text so it's easier for everybody to find theirs.