### PR TITLE
Legal notice string is missing in the FAQ

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -184,7 +184,7 @@ var Faq = React.createClass({
             </Panel>
 
             <Panel activeKey={activeKey} activateKey={this.onKeyChange} itemKey="item_tax_a" header={this.context.intl.formatHTMLMessage({id: 'faq_item_tax_header'})}>
-              <p><FormattedHTMLMessage id='donation_notice'/> <FormattedHTMLMessage id='faq_item_tax_paragraph_a_tax_id'/></p>
+              <p><FormattedHTMLMessage id='donation_notice_2'/> <FormattedHTMLMessage id='faq_item_tax_paragraph_a_tax_id'/></p>
               <p><FormattedHTMLMessage id='faq_item_tax_paragraph_b'/></p>
               <p><FormattedHTMLMessage id='faq_item_tax_paragraph_c'/></p>
             </Panel>

--- a/src/pages/thunderbird/faq.js
+++ b/src/pages/thunderbird/faq.js
@@ -260,7 +260,7 @@ var Faq = React.createClass({
             </Panel>
 
             <Panel activeKey={activeKey} activateKey={this.onKeyChange} itemKey="item_tax_a" header={this.context.intl.formatHTMLMessage({id: 'faq_item_tax_header'})}>
-              <p><FormattedHTMLMessage id='donation_notice'/> <FormattedHTMLMessage id='faq_item_tax_paragraph_a_tax_id'/></p>
+              <p><FormattedHTMLMessage id='donation_notice_2'/> <FormattedHTMLMessage id='faq_item_tax_paragraph_a_tax_id'/></p>
               <p><FormattedHTMLMessage id='faq_item_tax_paragraph_b'/></p>
               <p><FormattedHTMLMessage id='faq_item_tax_paragraph_c'/></p>
             </Panel>


### PR DESCRIPTION
@ScottDowne Mind giving it a quick look and deploy this one when the pipes are green?

It’s fixing this on both FAQs
![image](https://user-images.githubusercontent.com/1294206/40997105-7db737d6-68fb-11e8-9f24-929db0744bca.png)

The string we changed for the legal notice in the footer was actually used in more places, and we forgot to update them