### PR TITLE
run all build tasks on npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mozilla's Donation Forms",
   "main": "start.js",
   "scripts": {
-    "start": "npm-run-all --parallel build:l10njson watch:js server",
+    "start": "npm-run-all build:* && npm-run-all --parallel watch:js server",
     "build:l10njson": "pontoon-to-json --dest ./public",
     "build:exchangerates": "node scripts/exchangerates.js",
     "build:babel": "babel src --compact=true -s --out-dir dist",


### PR DESCRIPTION
Previously the watch task would need to be running and code altered to get all the necessary build tasks to run...