### PR TITLE
Fixing bug with thunderbird small print sections.

### DIFF
--- a/src/components/single-form.js
+++ b/src/components/single-form.js
@@ -9,6 +9,7 @@ import { PayPalButton, StripeButton } from './payment-options.js';
 import SubmitButton from './submit-button.js';
 import DonateButton from './donate-button.js';
 import SmallPrint from './small-print.js';
+import SmallPrintThunderbird from './thunderbird/small-print.js';
 import currencies from '../data/currencies.js';
 
 import { connect } from 'react-redux';
@@ -91,6 +92,16 @@ var singleForm = React.createClass({
 
     return this.renderWithDisabledCurrency(className);
   },
+  renderSmallPrint: function() {
+    if (this.props.appName === "thunderbird") {
+      return (
+        <SmallPrintThunderbird frequency={this.props.frequency}/>
+      );
+    }
+    return (
+      <SmallPrint frequency={this.props.frequency}/>
+    );
+  },
   renderBaseForm: function() {
     return (
       <div>
@@ -109,7 +120,7 @@ var singleForm = React.createClass({
           submitting={this.state.submitting === PAYPAL_SUBMITTING}
           onSubmit={this.validatePaypal}
         />
-        <SmallPrint frequency={this.props.frequency}/>
+        {this.renderSmallPrint()}
       </div>
     );
   },
@@ -135,7 +146,7 @@ var singleForm = React.createClass({
             </SubmitButton>
           </div>
         </div>
-        <SmallPrint frequency={this.props.frequency}/>
+        {this.renderSmallPrint()}
       </div>
     );
   }

--- a/src/components/single-form.js
+++ b/src/components/single-form.js
@@ -93,13 +93,9 @@ var singleForm = React.createClass({
     return this.renderWithDisabledCurrency(className);
   },
   renderSmallPrint: function() {
-    if (this.props.appName === "thunderbird") {
-      return (
-        <SmallPrintThunderbird frequency={this.props.frequency}/>
-      );
-    }
+    let Type = (this.props.appName === "thunderbird") ? SmallPrintThunderbird : SmallPrint;
     return (
-      <SmallPrint frequency={this.props.frequency}/>
+      <Type frequency={this.props.frequency}/>
     );
   },
   renderBaseForm: function() {

--- a/src/components/thunderbird/small-print.js
+++ b/src/components/thunderbird/small-print.js
@@ -9,9 +9,14 @@ var Footer = React.createClass({
   render: function() {
     var wireTransferLink = (<Link to={'/' + this.context.intl.locale + '/thunderbird/faq#item_2'}>{this.context.intl.formatMessage({id: 'wireTransfer'})}</Link>);
     var checkLink = (<a href={'/' + this.context.intl.locale + '/thunderbird/faq#item_4'}>{this.context.intl.formatMessage({id: 'check'})}</a>);
+    var privacyPolicyMessage = "privacy_policy_var_b";
+    if (this.props.frequency === "monthly") {
+      privacyPolicyMessage = "privacy_policy_var_b_monthly";
+    }
     return (
       <div className="row disclaimers">
-        <p className="other-ways-to-give">
+        <p className="full"><FormattedHTMLMessage id={privacyPolicyMessage}/></p>
+        <p className="full other-ways-to-give">
           <FormattedMessage
             id='other_way_to_give_wire_check'
             values={{
@@ -20,10 +25,10 @@ var Footer = React.createClass({
             }}
           />
         </p>
-        <p className="need-help">
+        <p className="full need-help">
           <FormattedHTMLMessage id="problems_donating_thunderbird2"/>
         </p>
-        <p className="donation-notice">
+        <p className="full donation-notice">
           {this.context.intl.formatMessage({id: 'donation_notice_thunderbird'})}
         </p>
       </div>


### PR DESCRIPTION
There are links in the small print section of the donate page that link out to various bits of info, some of these are mozilla specific, and some are thunderbird specific.

Before the reskin, the small print lived outside the generic form component and inside the pages themselves, which were specific to thunderbird or mozilla, so it was easy to display the correct small print bits.

When we did the reskin and moved this small print section into the form component I forgot to add a thunderbird version. So links in the small print for thunderbird started to link to mozilla specific stuff.

STRs:
1. go to donate.mozilla.org/thunderbird
2. click on any of the links in the disclaimer that are thunderbird specific, example: either of these "Wire Transfer or SEPA | Check"

Expected: should go to articles listed on the thunderbird faq
Actual: goes to articles on the mozilla donate faq

The fix:

There is already a thunderbird specific small print component to go along with the mozilla one. We need to do 2 things.
1. Update the old thunderbird small print to properly display in the new place.
2. Ensure the form component has the ability to display one or the other.