### PR TITLE
Removing email link from footer

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -10,7 +10,6 @@ var Footer = React.createClass({
         <div className="footer">
           <div className="footer-links">
             <ul>
-              <li><a href="mailto:network@mozillafoundation.org" target="_blank">{this.context.intl.formatMessage({id: 'email_footer'})}</a></li>
               <li><a href="https://twitter.com/mozilla" target="_blank">{this.context.intl.formatMessage({id: 'twitter'})}</a></li>
               <li><a href="https://www.facebook.com/mozilla" target="_blank">{this.context.intl.formatMessage({id: 'facebook'})}</a></li>
               <li>


### PR DESCRIPTION
As discussed with Will, we shouldn’t expose this email address in the footer in its current state. network@ would receive a lot of donor care emails that should instead go to donate@