### PR TITLE
Add download link banner to Thunderbird post-download donation page.

### DIFF
--- a/less/pages/thunderbird.less
+++ b/less/pages/thunderbird.less
@@ -1,4 +1,13 @@
 .thunderbird {
+  .download-failed {
+    text-align: center;
+    background: #fff;
+    h3 {
+      font-weight: 700;
+      font-family: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    }  
+  }
+
   &.thank-you-page,
   &.share-page {
     display: block;

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -71,6 +71,8 @@ additional_info_thunderbird=We’re the leading open source cross-platform email
 additional_info_thunderbird_2=While Thunderbird is now an independent project separate from Mozilla, Mozilla has agreed to collect donations on our behalf.
 # String only displayed on https://donate-mozilla-org-us-staging.herokuapp.com/thunderbird/?test=tbdownload
 thunderbird_thank_you_note=Thank you for downloading Thunderbird!
+# String only displayed on https://donate-mozilla-org-us-staging.herokuapp.com/thunderbird/?test=tbdownload
+thunderbird_download_banner=Your download should have begun automatically. If it didn’t work, <a href="https://www.thunderbird.net/download/">try downloading again here</a>.
 
 # Paypal donate page
 select_donation=Select your donation amount

--- a/src/pages/thunderbird/about.js
+++ b/src/pages/thunderbird/about.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedHTMLMessage } from 'react-intl';
 import ThunderbirdFooter from '../../components/thunderbird/footer.js';
 import SingleForm from '../../components/single-form.js';
 
@@ -28,13 +29,18 @@ module.exports = React.createClass({
     });
   },
   render: function() {
+    var downloadBanner = "";
     var className = "row additional-info-container thunderbird";
     if (this.props.test) {
       className += " " + this.props.test;
     }
+    if (this.props.test === "tbdownload") {
+      downloadBanner = (<div className="download-failed"><h3><FormattedHTMLMessage id="thunderbird_download_banner" /></h3></div>);
+    }
     var aboutCopy = this.state.aboutCopy;
     return (
       <div className={className}>
+        {downloadBanner}
         <div className="additional-info-page">
           <div className="container additional-page">
             <img className="internet-graphic" width="224" src="/assets/images/thunderbird/thunderbird-logo-wordmark-small.png"/>


### PR DESCRIPTION
Hey,

We'd like to add a banner linking back to the Thunderbird site on the post-download donation page. The reason is because some people are confused by the redirect, or their download doesn't start, making them feel forced to donate or unable to download from the front page.

Here's what that looks like: ![image](https://user-images.githubusercontent.com/479671/44243367-9ce76c00-a183-11e8-9875-d07824c9dbf7.png)

I haven't done much with React before, so let me know if there's a better way to do any of this, I just chose what appeared to be the least invasive way.