### PR TITLE
Issue #2071: Fix Thunderbird download banner and change query variable to avoid conflicts.

### DIFF
--- a/src/pages/thunderbird/about.js
+++ b/src/pages/thunderbird/about.js
@@ -15,7 +15,7 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     var aboutCopy = (<span>{this.context.intl.formatMessage({id: 'additional_info_thunderbird'})}</span>);
-    if (this.props.test === "tbdownload") {
+    if (this.props.location.query.tbdownload === "true") {
       aboutCopy = (
         <span>
           <div><b>{this.context.intl.formatMessage({id: 'thunderbird_thank_you_note'})}</b></div>
@@ -31,10 +31,7 @@ module.exports = React.createClass({
   render: function() {
     var downloadBanner = "";
     var className = "row additional-info-container thunderbird";
-    if (this.props.test) {
-      className += " " + this.props.test;
-    }
-    if (this.props.test === "tbdownload") {
+    if (this.props.location.query.tbdownload === "true") {
       downloadBanner = (<div className="download-failed"><h3><FormattedHTMLMessage id="thunderbird_download_banner" /></h3></div>);
     }
     var aboutCopy = this.state.aboutCopy;


### PR DESCRIPTION
This uses a new query string variable for Thunderbird rather than overloading the 'test' one that is used for other things.

I noticed that these are defined in src/lib/QueryParser.js, but I'm not sure what benefit there is to putting them in there rather than just using this.props.location.query, and that seems to work fine, so I did not modify QueryParser.js so as to not add thunderbird-related clutter that may not be useful to you guys.

If there is a reason that query variables need to be parsed first in that file, let me know and I'll change it.