### PR TITLE
Remove a-b test for homepage image

### DIFF
--- a/assets/js/ab-tests.js
+++ b/assets/js/ab-tests.js
@@ -1,12 +1,17 @@
 // Documentation for running AB tests. https://github.com/mozilla/trafficcop/blob/master/documentation.md
 
-// Only run this test on the home page in en-US.
-var tc = new Mozilla.TrafficCop({
-    id: "image-experiment",
-    variations: {
-      "test=img-a": 50,
-      "test=no-img": 50
-    }
-});
+//*********************/
+//Traffic cop seems to break IE11. Next time we enable this, let's run a check and avoid running on IE11
+/*************************/
 
-tc.init();
+
+// Only run this test on the home page in en-US.
+// var tc = new Mozilla.TrafficCop({
+//     id: "image-experiment",
+//     variations: {
+//       "test=img-a": 50,
+//       "test=no-img": 50
+//     }
+// });
+
+// tc.init();

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -20,21 +20,14 @@ module.exports = React.createClass({
       aboutCopy: aboutCopy
     });
   },
-  imageTest: function() {
-    let test = this.props.test;
 
-    if (test === "img-a") {
-      return (<picture>
-        <source width="1448" srcSet="/assets/images/homepage-images/teacher-wide.jpg" media="(max-width: 799px)" />
-        <img className="homepage-image" src="/assets/images/homepage-images/teacher-full.jpg" alt="Man pointing at student's computer screen"/>
-      </picture> );
-    }
-    return (<img className="homepage-image icon-baseline" height="100" width="107" alt="heart" src="/assets/images/heart.ce7d2d59c757e1598e244e546426577c.svg"/>);
-  },
   renderTextAboutPage: function() {
     return (
       <div className="container additional-page">
-        { this.imageTest() }
+        <picture>
+          <source width="1448" srcSet="/assets/images/homepage-images/teacher-wide.jpg" media="(max-width: 799px)" />
+          <img className="homepage-image" src="/assets/images/homepage-images/teacher-full.jpg" alt="Man pointing at student's computer screen"/>
+        </picture> 
         <div>
           { this.state.aboutCopy }
         </div>


### PR DESCRIPTION
Closes #2103 

May fix IE11 donations (#2097)

I didn't remove the heart image because I'm not entirely sure it's not used elsewhere.