### PR TITLE
Enable IPv6 dualstack on the CloudFront distribution

### DIFF
--- a/ops/cloudformation.json
+++ b/ops/cloudformation.json
@@ -163,6 +163,7 @@
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
+          "IPV6Enabled": true,
           "Logging": {
             "IncludeCookies": "false",
             "Bucket": {


### PR DESCRIPTION
Should make it possible to visit the donation page over IPv6 once deployed.