### PR TITLE
Add A/B testing for our about sidebar text in EN locales

### DIFF
--- a/assets/js/ab-tests.js
+++ b/assets/js/ab-tests.js
@@ -22,7 +22,6 @@ if (typeof Mozilla !== "undefined" && Mozilla.TrafficCop) {
     }
   })).init();
 
-  /*
   // This test runs on the main page (Currently about.js), for en-US only
   (new Mozilla.TrafficCop({
     id: "side-text",
@@ -31,5 +30,4 @@ if (typeof Mozilla !== "undefined" && Mozilla.TrafficCop) {
       "test=nst": 50  // New Side Text
     }
   })).init();
-  */
 }

--- a/assets/js/ab-tests.js
+++ b/assets/js/ab-tests.js
@@ -13,14 +13,23 @@
 
 if (typeof Mozilla !== "undefined" && Mozilla.TrafficCop) {
 
-  // Only run this test on the home page in en-US.
-  var tc = new Mozilla.TrafficCop({
+  // This test runs in amount-buttons.jsx
+  (new Mozilla.TrafficCop({
     id: "button-ordering",
     variations: {
-      "test=lth": 50,
-      "test=htl": 50
+      "test=lth": 50, // Low To High
+      "test=htl": 50  // High To Low
     }
-  });
+  })).init();
 
-  tc.init();
+  /*
+  // This test runs on the main page (Currently about.js), for en-US only
+  (new Mozilla.TrafficCop({
+    id: "side-text",
+    variations: {
+      "test=ost": 50, // Original Side Text
+      "test=nst": 50  // New Side Text
+    }
+  })).init();
+  */
 }

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -67,6 +67,7 @@ participation_guidelines=Participation Guidelines
 
 # About page
 additional_info_internet_health_bold=<b>We are proudly non-profit</b>, non-corporate and non-compromised. Thousands of people like you help us stand up for a healthy internet for all. We rely on donations to carry out our mission to keep the Web open and free. Will you give today?
+updated_additional_info_internet_health_bold=With a deep respect for our supporters’ privacy and a unique global reach, the non-profit Mozilla Foundation fights every day for a healthier internet, through projects like our *Privacy Not Included buyer’s guide. <b>This work depends on contributions from people like you. Will you chip in today?</b>
 additional_info_thunderbird=We’re the leading open source cross-platform email and calendaring client, free for business and personal use. By donating you’ll help ensure it stays that way and contribute towards future development. Will you give today?
 additional_info_thunderbird_2=While Thunderbird is now an independent project separate from Mozilla, Mozilla has agreed to collect donations on our behalf.
 # String only displayed on https://donate-mozilla-org-us-staging.herokuapp.com/thunderbird/?test=tbdownload

--- a/src/components/amount-buttons.js
+++ b/src/components/amount-buttons.js
@@ -212,12 +212,13 @@ var AmountButtons = React.createClass({
 
     // Test conversion based on donation amount ordering.
     var test = this.props.test;
-    if (test !== "htl") {
-      // low-to-high presentation
-      presets.sort((a,b) => parseFloat(a) - parseFloat(b));
-    } else if (test === "htl") {
+
+    if (test && test.indexOf('htl') > -1) {
       // high-to-low presentation
       presets.sort((a,b) => parseFloat(b) - parseFloat(a));
+    } else {
+      // low-to-high presentation
+      presets.sort((a,b) => parseFloat(a) - parseFloat(b));
     }
 
     return (

--- a/src/lib/detect-ie.js
+++ b/src/lib/detect-ie.js
@@ -1,0 +1,29 @@
+module.exports = function detectIE(ua) {
+  var haveWindow = typeof window;
+
+  if (!ua && haveWindow) {
+      ua = window.navigator.userAgent;
+  }
+
+  if (!ua) {
+      return false;
+  }
+
+  var msie = ua.indexOf('MSIE ');
+  if (msie > -1) {
+      // IE 10 or older => return version number
+      return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+  }
+
+  var trident = ua.indexOf('Trident/');
+  if (trident > -1) {
+      // IE 11 => return version number
+      var rv = ua.indexOf('rv:');
+      return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+  }
+
+  // Not a version of IE, or it's IE but it's lying about
+  // who it is and then that's the user's responsibility,
+  // really.
+  return false;
+};

--- a/src/lib/queryParser.js
+++ b/src/lib/queryParser.js
@@ -29,9 +29,9 @@ module.exports = function(queryString, locale) {
     presets = currency.presets[frequency];
   }
 
-  // Collaps test to a string if it happens to be an array.
-  if (test && test.join) {
-    test = test.join(" ");
+  // Ensure test is always an array of strings.
+  if (typeof test === "string") {
+    test = [test];
   }
 
   var parsed = {

--- a/src/lib/react-server-route.js
+++ b/src/lib/react-server-route.js
@@ -5,7 +5,7 @@ import React from 'react';
 import url from 'url';
 import queryParser from './queryParser.js';
 var langmap = require("langmap");
-var HTML = require('../pages/index.js');
+var IndexPage = require('../pages/index.js');
 
 function routeFileContent(locales) {
   var locationParser = require('./location-parser.js')(langmap, locales);
@@ -66,7 +66,7 @@ function routeFileContent(locales) {
       // the bundle for hooking into the DOM.
       var reactHTML = renderToString(<RouterContext createElement={createElement} {...renderProps}/>);
       var html = renderToStaticMarkup(
-        <HTML
+        <IndexPage
           localesInfo={localesInfo}
           locale={locale}
           favicon={favicon}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -13,7 +13,7 @@ module.exports = React.createClass({
     var test = this.props.test;
 
     // Run our copy test only on English locale:
-    if (test && test.indexOf('nst') > -1 && this.context.intl.locale === "en-US") {
+    if (test && test.indexOf('nst') > -1 && this.context.intl.locale.indexOf("en") > -1) {
       // New Side Text copy from ./locales/en-US/messages.properties
       aboutCopy = (<span><FormattedHTMLMessage id="updated_additional_info_internet_health_bold"/></span>);
     }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -9,18 +9,19 @@ module.exports = React.createClass({
     intl: React.PropTypes.object
   },
   getInitialState: function() {
+    var aboutCopy = (<span><FormattedHTMLMessage id="additional_info_internet_health_bold"/></span>);
+    var test = this.props.test;
+
+    // Run our copy test only on English locale:
+    if (test && test.indexOf('nst') > -1 && this.context.intl.locale === "en-US") {
+      // New Side Text copy from ./locales/en-US/messages.properties
+      aboutCopy = (<span><FormattedHTMLMessage id="updated_additional_info_internet_health_bold"/></span>);
+    }
+
     return {
-      aboutCopy: null
+      aboutCopy: aboutCopy
     };
   },
-  componentDidMount: function() {
-    var aboutCopy = (<span><FormattedHTMLMessage id="additional_info_internet_health_bold"/></span>);
-
-    this.setState({
-      aboutCopy: aboutCopy
-    });
-  },
-
   renderTextAboutPage: function() {
     return (
       <div className="container additional-page">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,8 +2,9 @@ import fs from 'fs';
 import React from 'react';
 import Path from 'path';
 import Pontoon from '../components/pontoon.js';
+import detectIE from '../lib/detect-ie.js';
 
-var Index = React.createClass({
+var IndexPage = React.createClass({
   render: function() {
     var metaData = this.props.metaData;
     var robots = 'index, follow';
@@ -31,11 +32,8 @@ var Index = React.createClass({
     }
 
     // bypass Traffic Cop for IE11
-    var bypassTrafficCop = false;
     var ua = metaData.user_agent;
-    if (ua && ua.indexOf("Trident") > -1) {
-      bypassTrafficCop = true;
-    }
+    var bypassTrafficCop = (detectIE(ua) !== false);
 
     return (
       <html dir={dir} lang={this.props.locale}>
@@ -95,4 +93,4 @@ var Index = React.createClass({
   }
 });
 
-module.exports = Index;
+module.exports = IndexPage;


### PR DESCRIPTION
This adds a new string to the messages.properties for `en-US` only, as per https://github.com/mozilla/donate.mozilla.org/issues/2129, and adds an A/B test that does a 50/50 content swap between the original text and the new text.