### PR TITLE
Add a Referrer-Policy Header and meta tag, with a same-origin policy value

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,20 @@ module.exports = async function(options) {
     encoding: "none"
   });
 
+  server.ext('onPreResponse', (request, h) => {
+    const response = request.response;
+    const headerName = 'Referrer-Policy';
+    const headerValue = 'same-origin';
+
+    if (response.isBoom) {
+      response.output.headers[headerName] = headerValue;
+    } else {
+      response.header(headerName, headerValue);
+    }
+
+    return h.continue;
+  });
+
   server.route(baseRoutes);
 
   await server.register(services);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,6 +44,7 @@ var Index = React.createClass({
           <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
           <meta name="viewport" content="width=device-width, initial-scale=1"/>
           <meta name='robots' content={robots}/>
+          <meta name="referrer" content="same-origin"/>
 
           <meta property="og:type" content="website" />
           <meta property="og:title" content={metaData.title} />


### PR DESCRIPTION
I set up a hook on the `onPreResponse` extension event that adds the `referrer-policy` header. I found that while clicking outbound links respected this policy, it was not respected for resources loaded by the document. The referrer meta tag solves this problem, ensuring that (in browsers that support referrer-policy - meaning most recent browsers except edge and IE11) the Referrer header isn't sent to third party domains.