### PR TITLE
Fix #2161 - don't (try to) pass window.grecaptcha.execute to expectRecaptcha which is going to wait for grecaptcha to become awailable.

### DIFF
--- a/src/mixins/stripe.js
+++ b/src/mixins/stripe.js
@@ -88,9 +88,10 @@ var StripeMixin = {
       return;
     }
     if (!window.grecaptcha) {
-      return setTimeout(() => {
+      setTimeout(() => {
         this.expectRecaptcha(callback);
       }, 100);
+      return;
     }
 
     window.grecaptcha.ready(callback);
@@ -115,7 +116,9 @@ var StripeMixin = {
     // This is a hack to get around the reCaptcha
     // puzzle being shown at the top of the page.
     window.scrollTo(0, 0);
-    this.expectRecaptcha(window.grecaptcha.execute);
+    this.expectRecaptcha(() => {
+      window.grecaptcha.execute();
+    });
   },
   stripeSubmit: function(reCaptchaToken) {
     var success = this.stripeSuccess;


### PR DESCRIPTION
At the time window.grecaptcha could still be unavailable. So, only access it after we know it's there.

I think this should work. But I don't get a captcha when testing locally with or without this patch... so unable to verify.